### PR TITLE
fix: handle ErrUnexpectedEOF in reader

### DIFF
--- a/proto/reader.go
+++ b/proto/reader.go
@@ -59,7 +59,7 @@ func (r *Reader) Decode(v Decoder) error {
 }
 
 func (r *Reader) ReadFull(buf []byte) error {
-	if _, err := io.ReadFull(r, buf); err != nil {
+	if _, err := io.ReadFull(r, buf); err != nil && err != io.ErrUnexpectedEOF {
 		return errors.Wrap(err, "read")
 	}
 	return nil


### PR DESCRIPTION
Hi there, I think we should consider handling the 'ErrUnexpectedEOF' in reader to fix this issue https://github.com/ClickHouse/clickhouse-go/issues/846