### PR TITLE
fix: close connection after query cancellation

### DIFF
--- a/query.go
+++ b/query.go
@@ -40,6 +40,11 @@ func (c *Client) cancelQuery() error {
 		return errors.Wrap(err, "flush")
 	}
 
+	// Closing connection to prevent further queries.
+	if err := c.Close(); err != nil {
+		return errors.Wrap(err, "close")
+	}
+
 	return nil
 }
 

--- a/query_test.go
+++ b/query_test.go
@@ -1384,7 +1384,7 @@ func TestClientQueryCancellation(t *testing.T) {
 		OnResult: func(_ context.Context, block proto.Block) error {
 			rows += block.Rows
 			if rows >= 500_000 {
-				t.Log("Cancelling query")
+				t.Log("Canceling query")
 				cancel()
 			}
 			return nil

--- a/query_test.go
+++ b/query_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/ClickHouse/ch-go/cht"
 	"github.com/ClickHouse/ch-go/proto"
 )
 
@@ -1358,4 +1359,38 @@ func TestClientInsert(t *testing.T) {
 			return nil
 		},
 	}))
+}
+
+func TestClientQueryCancellation(t *testing.T) {
+	ctx := context.Background()
+	server := cht.New(t)
+	c, err := Dial(ctx, Options{
+		Address: server.TCP,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+	require.NoError(t, c.Ping(ctx))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Performing query cancellation.
+	var (
+		rows int
+		data proto.ColUInt64
+	)
+	require.Error(t, c.Do(ctx, Query{
+		Body:   fmt.Sprintf("SELECT number as v FROM system.numbers LIMIT %d", 2_500_000),
+		Result: proto.Results{{Name: "v", Data: &data}},
+		OnResult: func(_ context.Context, block proto.Block) error {
+			rows += block.Rows
+			if rows >= 500_000 {
+				t.Log("Cancelling query")
+				cancel()
+			}
+			return nil
+		},
+	}))
+
+	// Connection should be closed after query cancellation.
+	require.True(t, c.IsClosed())
 }


### PR DESCRIPTION
We are doing same in clickhouse-go, so should be fine.

Fix #235