### PR TITLE
chore: automatic column inference for the UUID column

### DIFF
--- a/proto/col_auto.go
+++ b/proto/col_auto.go
@@ -58,6 +58,12 @@ func (c *ColAuto) Infer(t ColumnType) error {
 		c.Data = new(ColDate)
 	case "Map(String,String)":
 		c.Data = NewMap[string, string](new(ColStr), new(ColStr))
+	case ColumnTypeUUID:
+		c.Data = new(ColUUID)
+	case ColumnTypeArray.Sub(ColumnTypeUUID):
+		c.Data = new(ColUUID).Array()
+	case ColumnTypeNullable.Sub(ColumnTypeUUID):
+		c.Data = new(ColUUID).Nullable()
 	default:
 		switch t.Base() {
 		case ColumnTypeDateTime:

--- a/proto/col_auto_test.go
+++ b/proto/col_auto_test.go
@@ -43,6 +43,9 @@ func TestColAuto_Infer(t *testing.T) {
 		ColumnTypeNothing,
 		"Nullable(Nothing)",
 		"Array(Nothing)",
+		ColumnTypeUUID,
+		ColumnTypeArray.Sub(ColumnTypeUUID),
+		ColumnTypeNullable.Sub(ColumnTypeUUID),
 	} {
 		r := AutoResult("foo")
 		require.NoError(t, r.Data.(Inferable).Infer(columnType))

--- a/proto/col_uuid.go
+++ b/proto/col_uuid.go
@@ -21,3 +21,13 @@ func (c ColUUID) Row(i int) uuid.UUID      { return c[i] }
 func (c *ColUUID) Reset()                  { *c = (*c)[:0] }
 func (c *ColUUID) Append(v uuid.UUID)      { *c = append(*c, v) }
 func (c *ColUUID) AppendArr(v []uuid.UUID) { *c = append(*c, v...) }
+
+// Nullable is helper that creates Nullable(uuid.UUID).
+func (c *ColUUID) Nullable() *ColNullable[uuid.UUID] {
+	return NewColNullable[uuid.UUID](c)
+}
+
+// Array is helper that creates Array of uuid.UUID.
+func (c *ColUUID) Array() *ColArr[uuid.UUID] {
+	return NewArray[uuid.UUID](c)
+}


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

This PR adds a type inference for the UUID column. Maybe we should have made it with the code generator, but this will make this PR very difficult.

Closes #310

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
