### PR TITLE
Client name

### DIFF
--- a/client.go
+++ b/client.go
@@ -420,20 +420,22 @@ type clientVersion struct {
 func Connect(ctx context.Context, conn net.Conn, opt Options) (*Client, error) {
 	opt.setDefaults()
 
+	clientName := proto.Name
 	pkg := pkgVersion.Get()
+	if opt.ClientName == "" {
+		if pkg.Name != "" {
+			clientName = fmt.Sprintf("%s (%s)", clientName, pkg.Name)
+		}
+	} else {
+		clientName = fmt.Sprintf("%s %s", clientName, opt.ClientName)
+	}
 	ver := clientVersion{
-		Name:  proto.Name,
+		Name:  clientName,
 		Major: pkg.Major,
 		Minor: pkg.Minor,
 		Patch: pkg.Patch,
 	}
-	if pkg.Name != "" {
-		ver.Name = fmt.Sprintf("%s (%s)", proto.Name, pkg.Name)
-	}
-	clientName := ver.Name
-	if opt.ClientName != "" {
-		clientName = fmt.Sprintf("%s %s", clientName, opt.ClientName)
-	}
+
 	if opt.OpenTelemetryInstrumentation {
 		newCtx, span := opt.tracer.Start(ctx, "Connect",
 			trace.WithSpanKind(trace.SpanKindClient),

--- a/client.go
+++ b/client.go
@@ -318,6 +318,7 @@ type Options struct {
 	Password    string      // blank string by default
 	QuotaKey    string      // blank string by default
 	Compression Compression // disabled by default
+	ClientName  string      // blank string by default
 	Settings    []Setting   // none by default
 
 	// ReadTimeout is a timeout for reading a single packet from the server.
@@ -429,6 +430,10 @@ func Connect(ctx context.Context, conn net.Conn, opt Options) (*Client, error) {
 	if pkg.Name != "" {
 		ver.Name = fmt.Sprintf("%s (%s)", proto.Name, pkg.Name)
 	}
+	clientName := ver.Name
+	if opt.ClientName != "" {
+		clientName = fmt.Sprintf("%s %s", clientName, opt.ClientName)
+	}
 	if opt.OpenTelemetryInstrumentation {
 		newCtx, span := opt.tracer.Start(ctx, "Connect",
 			trace.WithSpanKind(trace.SpanKindClient),
@@ -457,7 +462,7 @@ func Connect(ctx context.Context, conn net.Conn, opt Options) (*Client, error) {
 		version:         ver,
 		protocolVersion: opt.ProtocolVersion,
 		info: proto.ClientHello{
-			Name:  ver.Name,
+			Name:  clientName,
 			Major: ver.Major,
 			Minor: ver.Minor,
 

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -4,5 +4,5 @@ package proto
 // Defaults for ClientHello.
 const (
 	Version = 54460
-	Name    = "go-faster/ch"
+	Name    = "clickhouse/ch-go"
 )


### PR DESCRIPTION
## Summary
Changes the protocol client name to `clickhouse/ch-go` and add the ability to extend that client name with a user supplied options.

