### PR TITLE
Fix Date32 overflow by changing its representation to int32

### DIFF
--- a/proto/date32.go
+++ b/proto/date32.go
@@ -5,16 +5,13 @@ import "time"
 // Date32 represents Date32 value.
 //
 // https://clickhouse.com/docs/en/sql-reference/data-types/date32/
-type Date32 uint32
-
-// date32Epoch is unix time of 1925-01-01.
-const date32Epoch = -1420070400
+type Date32 int32
 
 // Unix returns unix timestamp of Date32.
 //
 // You can use time.Unix(d.Unix(), 0) to get Time in time.Local location.
 func (d Date32) Unix() int64 {
-	return secInDay*int64(d) + date32Epoch
+	return secInDay * int64(d)
 }
 
 // Time returns UTC starting time.Time of Date32.
@@ -29,7 +26,7 @@ func (d Date32) String() string {
 // ToDate32 returns Date32 of time.Time.
 func ToDate32(t time.Time) Date32 {
 	_, offset := t.Zone()
-	return Date32((t.Unix() + int64(offset) - date32Epoch) / secInDay)
+	return Date32((t.Unix() + int64(offset)) / secInDay)
 }
 
 // NewDate32 returns the Date32 corresponding to year, month and day in UTC.

--- a/proto/date32_test.go
+++ b/proto/date32_test.go
@@ -13,7 +13,7 @@ func TestDate32_Time(t *testing.T) {
 	t.Run("Single", func(t *testing.T) {
 		v := time.Date(2011, 10, 10, 14, 59, 31, 401235, time.UTC)
 		d := ToDate32(v)
-		assert.Equal(t, Date32(31693), d)
+		assert.Equal(t, Date32(15257), d) // SELECT toInt64(Date32('2011-10-10'))
 		assert.Equal(t, NewDate32(2011, 10, 10), d)
 		assert.Equal(t, d.String(), "2011-10-10")
 		assert.Equal(t, d, ToDate32(d.Time()))


### PR DESCRIPTION
Change `Date32` representation to signed 32bit integer. Fixes issues with wrong data representation for Date32 for native format.

Resolves #319 