### PR TITLE
fix(proto.reader): remove str length limit

### DIFF
--- a/proto/reader.go
+++ b/proto/reader.go
@@ -87,8 +87,6 @@ func (r *Reader) UVarInt() (uint64, error) {
 	return n, nil
 }
 
-const maxStrSize = 10 * 1024 * 1024 // 10 MB
-
 func (r *Reader) StrLen() (int, error) {
 	n, err := r.Int()
 	if err != nil {
@@ -97,10 +95,6 @@ func (r *Reader) StrLen() (int, error) {
 
 	if n < 0 {
 		return 0, errors.Errorf("size %d is invalid", n)
-	}
-	if n > maxStrSize {
-		// Protecting from possible OOM.
-		return 0, errors.Errorf("size %d too big (%d is maximum)", n, maxStrSize)
 	}
 
 	return n, nil


### PR DESCRIPTION
## Summary
Remove the hardcoded string length limit. Give the possibility to retrieve strings bigger than 10MB.
## Checklist
- [x] A human-readable description of the changes was provided to include in CHANGELOG

related to https://github.com/ClickHouse/clickhouse-go/issues/867