### PR TITLE
implement Exception.Unwrap method

### DIFF
--- a/client.go
+++ b/client.go
@@ -131,6 +131,25 @@ func (e *Exception) Error() string {
 	return fmt.Sprintf("%s: %s: %s", e.Code, e.Name, msg)
 }
 
+// Unwrap implements errors.Unwrap interface.
+func (e *Exception) Unwrap() []error {
+	if e == nil {
+		return nil
+	}
+	// Flatten error tree by collecting all error codes.
+	// Only check error codes since only they can be compared using errors.Is.
+	// Dynamically created Exceptions are not relevant for this functionality.
+	return e.collectCodes(nil)
+}
+
+func (e *Exception) collectCodes(codes []error) []error {
+	result := append(codes, e.Code)
+	for _, next := range e.Next {
+		result = next.collectCodes(result)
+	}
+	return result
+}
+
 // AsException finds first *Exception in err chain.
 func AsException(err error) (*Exception, bool) {
 	var e *Exception

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package ch
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
@@ -86,4 +87,30 @@ func TestDial(t *testing.T) {
 		})
 		require.True(t, IsErr(err, proto.ErrUnknownDatabase))
 	})
+}
+
+func TestExceptionUnwrap(t *testing.T) {
+	flat := &Exception{
+		Code:    proto.ErrReadonly,
+		Name:    "foo",
+		Message: "bar",
+		Next:    nil,
+	}
+
+	if !errors.Is(flat, proto.ErrReadonly) {
+		t.Fatal("flat exception must be the error code it represents")
+	}
+
+	nested := &Exception{
+		Code:    proto.ErrAborted,
+		Name:    "foo",
+		Message: "bar",
+		Next:    []Exception{*flat},
+	}
+	if !errors.Is(nested, proto.ErrAborted) {
+		t.Fatal("nested exception must be the error code it represents")
+	}
+	if !errors.Is(nested, proto.ErrReadonly) {
+		t.Fatal("nested exception must be the error code it wraps")
+	}
 }


### PR DESCRIPTION
In order to make exceptions testable with errors.Is, they must implement the `Unwrap` method to allow access to the underlying error code(s).

This change is addressing the problem of the below code not working as expected, when testing returned by `Do` method error:

    c, _ := ch.Dial(ctx, ch.Options{...})
    switch err := c.Do(ctx, ch.Query{...}); {
    case err == nil:
    	// ...
    case errors.Is(err, proto.ErrTableIsReadOnly), errors.Is(err, proto.ErrReadonly):
    	// ... <- Never executed, because exception unwraping is not implemented.
    default:
        // ...
    }

Because `Exception` instances are created dynamically, unwrapping can ignore nested exception instances and collect only the underlying error codes.
