### PR TITLE
fix(query): add with totals case (issue #382)

### DIFF
--- a/query.go
+++ b/query.go
@@ -720,7 +720,7 @@ func (c *Client) Do(ctx context.Context, q Query) (err error) {
 				return errors.Wrap(err, "packet")
 			}
 			switch code {
-			case proto.ServerCodeData:
+			case proto.ServerCodeData, proto.ServerCodeTotals:
 				if err := c.decodeBlock(ctx, decodeOptions{
 					Handler:      onResult,
 					Result:       q.Result,


### PR DESCRIPTION
## Summary
A suggestion on how to resolve https://github.com/ClickHouse/ch-go/issues/382#issue-2146490836
With these changes, the totals row will be returned as the last row of the result.

## Checklist
- [V] Unit and integration tests covering the common scenarios were added
- [V] A human-readable description of the changes was provided to include in CHANGELOG