### PR TITLE
fix(proto): DateTime/DateTime64 with '1970-01-01 00:00:00 UTC'

### DIFF
--- a/proto/datetime.go
+++ b/proto/datetime.go
@@ -15,9 +15,6 @@ func ToDateTime(t time.Time) DateTime {
 
 // Time returns DateTime as time.Time.
 func (d DateTime) Time() time.Time {
-	if d == 0 {
-		return time.Time{}
-	}
 	// https://clickhouse.com/docs/en/sql-reference/data-types/datetime/#usage-remarks
 	// ClickHouse stores UTC timestamps that are timezone-agnostic.
 	return time.Unix(int64(d), 0)

--- a/proto/datetime64.go
+++ b/proto/datetime64.go
@@ -57,9 +57,6 @@ func ToDateTime64(t time.Time, p Precision) DateTime64 {
 
 // Time returns DateTime64 as time.Time.
 func (d DateTime64) Time(p Precision) time.Time {
-	if d == 0 {
-		return time.Time{}
-	}
 	nsec := int64(d) * p.Scale()
 	return time.Unix(nsec/1e9, nsec%1e9)
 }

--- a/proto/datetime64_test.go
+++ b/proto/datetime64_test.go
@@ -18,7 +18,7 @@ func TestDateTime64_Time(t *testing.T) {
 	} {
 		t.Run(p.Duration().String(), func(t *testing.T) {
 			for _, v := range []time.Time{
-				{}, // zero time
+				time.Unix(0, 0).UTC(), // zero time
 				time.Unix(1546290000, 0).UTC(),
 			} {
 				d := ToDateTime64(v, p)
@@ -27,6 +27,21 @@ func TestDateTime64_Time(t *testing.T) {
 				assert.Equal(t, v.Unix(), vt.Unix())
 				assert.True(t, p.Valid())
 			}
+		})
+
+		t.Run("Zero_"+p.Duration().String(), func(t *testing.T) {
+			t1 := time.Time{}
+			t2 := time.Unix(0, 0).UTC()
+			d1 := ToDateTime64(t1, p)
+			d2 := ToDateTime64(t2, p)
+			vt1 := d1.Time(p)
+			vt2 := d2.Time(p)
+
+			assert.True(t, t1.IsZero())
+			assert.False(t, t2.IsZero())
+			assert.Equal(t, d1, d2)
+			assert.Equal(t, vt1.Unix(), int64(0))
+			assert.Equal(t, vt2.Unix(), int64(0))
 		})
 	}
 	t.Run("Duration", func(t *testing.T) {

--- a/proto/datetime_test.go
+++ b/proto/datetime_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDateTime_Time(t *testing.T) {
+func TestDateTime_ToDateTime(t *testing.T) {
 	t.Run("Ok", func(t *testing.T) {
 		v := time.Unix(1546290000, 0).UTC()
 		d := ToDateTime(v)
@@ -17,5 +17,24 @@ func TestDateTime_Time(t *testing.T) {
 		v := time.Time{}
 		d := ToDateTime(v)
 		assert.Equal(t, int32(0), int32(d))
+	})
+}
+
+func TestDateTime_Time(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		d := DateTime(1546290000)
+		assert.Equal(t, d.Time().Unix(), int64(1546290000))
+	})
+
+	t.Run("Zero", func(t *testing.T) {
+		d := DateTime(0)
+		assert.Equal(t, d.Time().Unix(), int64(0))
+	})
+
+	t.Run("IsZero", func(t *testing.T) {
+		d1 := DateTime(0)
+		d2 := time.Time{}
+		assert.Equal(t, d1.Time().IsZero(), false)
+		assert.Equal(t, d2.IsZero(), true)
 	})
 }


### PR DESCRIPTION
## Summary
I use clickhouse-cli and clickhouse-go to execute the following SQL, but I get different results：
```
localhost :) select toDateTime('1970-01-01 00:00:00', 'UTC');

SELECT toDateTime('1970-01-01 00:00:00', 'UTC')

Query id: 1b43d122-7f5f-44fa-9f3b-4992bd305998

┌─toDateTime('1970-01-01 00:00:00', 'UTC')─┐
│                      1970-01-01 00:00:00 │
└──────────────────────────────────────────┘

1 row in set. Elapsed: 0.002 sec. 
```

```go
func main() {
	conn, err := ConnectNative()
	if err != nil {
		panic((err))
	}

	query := "select toDateTime('1970-01-01 00:00:00', 'UTC')"
	var rows driver.Rows
	rows, _ = conn.Query(context.Background(), query)
	for rows.Next() {
		var ts time.Time
		err = rows.Scan(&ts)
		fmt.Println("ts", ts)
	}
}

func ConnectNative() (driver.Conn, error) {
	return clickhouse.Open(&clickhouse.Options{
		Addr: []string{"127.0.0.1:9000"},
	})
}
```
running result:
```
ts 0001-01-01 00:00:00 +0000 UTC
```

I noticed that the reason for the discrepancy in the above results is that  ch-go will treat `time.Time{}`  as `time.Unix(0,0).UTC()`, which is actually not the same in golang:
```go
t1, _ := time.Parse("2006-01-02 15:04:05", "1970-01-01 00:00:00")
t2 := time.Time{}
t3, _ := time.Parse("2006-01-02 15:04:05", "1970-01-01 00:00:01")
fmt.Printf("isZero => t1: %v, t2: %v\n", t1.IsZero(), t2.IsZero())         // isZero => t1: false, t2: true
fmt.Printf("UnixTime => t1: %v, t2: %v, t3:%v\n", t1.Unix(), t2.Unix(), t3.Unix())   // UnixTime => t1: 0, t2: -62135596800, t3:1
```

The same issue in clickhouse-go: [#1222](https://github.com/ClickHouse/clickhouse-go/issues/1222)

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
