### PR TITLE
Adds support for zero value time for date types.

### DIFF
--- a/proto/date.go
+++ b/proto/date.go
@@ -33,6 +33,9 @@ func (d Date) String() string {
 
 // ToDate returns Date of time.Time.
 func ToDate(t time.Time) Date {
+	if t.IsZero() {
+		return 0
+	}
 	_, offset := t.Zone()
 	return Date((t.Unix() + int64(offset)) / secInDay)
 }

--- a/proto/date32.go
+++ b/proto/date32.go
@@ -25,6 +25,9 @@ func (d Date32) String() string {
 
 // ToDate32 returns Date32 of time.Time.
 func ToDate32(t time.Time) Date32 {
+	if t.IsZero() {
+		return 0
+	}
 	_, offset := t.Zone()
 	return Date32((t.Unix() + int64(offset)) / secInDay)
 }

--- a/proto/date32_test.go
+++ b/proto/date32_test.go
@@ -36,20 +36,44 @@ func TestDate32_Time(t *testing.T) {
 }
 
 func TestToDate32(t *testing.T) {
+	const secInMinute = 60
+	const secInHour = 60 * secInMinute
 	for _, tc := range []struct {
-		Value string
+		name     string
+		Value    time.Time
+		expected *Date32
 	}{
-		{Value: "2006-01-02T06:04:03+07:00"},
-		{Value: "2008-01-02T06:44:15+03:00"},
-		{Value: "2009-01-01T06:03:31+12:00"},
-		{Value: "2006-12-31T22:04:41-06:30"},
+		{
+			name:  "2006-01-02T06:04:03+07:00",
+			Value: time.Date(2006, 1, 2, 6, 4, 3, 0, time.FixedZone("UTC+7", 7*secInHour)),
+		},
+		{
+			name:  "2008-01-02T06:44:15+03:00",
+			Value: time.Date(2008, 1, 2, 6, 44, 15, 0, time.FixedZone("UTC+3", 3*secInHour)),
+		},
+		{
+			name:  "2009-01-01T06:03:31+12:00",
+			Value: time.Date(2009, 1, 1, 6, 3, 31, 0, time.FixedZone("UTC+12", 12*secInHour)),
+		},
+		{
+			name:  "2006-12-31T22:04:41-06:30",
+			Value: time.Date(2006, 12, 31, 22, 4, 41, 0, time.FixedZone("UTC-6:30", -6*secInHour-30*secInMinute)),
+		},
+		{
+			name:     "zero value",
+			Value:    time.Time{},
+			expected: new(Date32),
+		},
 	} {
-		t.Run(tc.Value, func(t *testing.T) {
-			v, err := time.Parse(time.RFC3339, tc.Value)
-			require.NoError(t, err)
-			d := ToDate32(v)
-			expected := NewDate32(v.Year(), v.Month(), v.Day())
-			assert.Equal(t, v.Format(DateLayout), d.String())
+		t.Run(tc.name, func(t *testing.T) {
+			d := ToDate32(tc.Value)
+			var expected Date32
+			if tc.expected != nil {
+				expected = *tc.expected
+			} else {
+				expected = NewDate32(tc.Value.Year(), tc.Value.Month(), tc.Value.Day())
+				assert.Equal(t, tc.Value.Format(DateLayout), d.String())
+			}
 			assert.Equal(t, expected.String(), d.String())
 			assert.Equal(t, expected, d)
 		})

--- a/proto/date_test.go
+++ b/proto/date_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDate_Time(t *testing.T) {
@@ -36,20 +35,44 @@ func TestDate_Time(t *testing.T) {
 }
 
 func TestToDate(t *testing.T) {
+	const secInMinute = 60
+	const secInHour = 60 * secInMinute
 	for _, tc := range []struct {
-		Value string
+		name     string
+		Value    time.Time
+		expected *Date
 	}{
-		{Value: "2006-01-02T06:04:03+07:00"},
-		{Value: "2008-01-02T06:44:15+03:00"},
-		{Value: "2009-01-01T06:03:31+12:00"},
-		{Value: "2006-12-31T22:04:41-06:30"},
+		{
+			name:  "2006-01-02T06:04:03+07:00",
+			Value: time.Date(2006, 1, 2, 6, 4, 3, 0, time.FixedZone("UTC+7", 7*secInHour)),
+		},
+		{
+			name:  "2008-01-02T06:44:15+03:00",
+			Value: time.Date(2008, 1, 2, 6, 44, 15, 0, time.FixedZone("UTC+3", 3*secInHour)),
+		},
+		{
+			name:  "2009-01-01T06:03:31+12:00",
+			Value: time.Date(2009, 1, 1, 6, 3, 31, 0, time.FixedZone("UTC+12", 12*secInHour)),
+		},
+		{
+			name:  "2006-12-31T22:04:41-06:30",
+			Value: time.Date(2006, 12, 31, 22, 4, 41, 0, time.FixedZone("UTC-6:30", -6*secInHour-30*secInMinute)),
+		},
+		{
+			name:     "zero value",
+			Value:    time.Time{},
+			expected: new(Date),
+		},
 	} {
-		t.Run(tc.Value, func(t *testing.T) {
-			v, err := time.Parse(time.RFC3339, tc.Value)
-			require.NoError(t, err)
-			d := ToDate(v)
-			expected := NewDate(v.Year(), v.Month(), v.Day())
-			assert.Equal(t, v.Format(DateLayout), d.String())
+		t.Run(tc.name, func(t *testing.T) {
+			d := ToDate(tc.Value)
+			var expected Date
+			if tc.expected != nil {
+				expected = *tc.expected
+			} else {
+				expected = NewDate(tc.Value.Year(), tc.Value.Month(), tc.Value.Day())
+				assert.Equal(t, tc.Value.Format(DateLayout), d.String())
+			}
 			assert.Equal(t, expected.String(), d.String())
 			assert.Equal(t, expected, d)
 		})


### PR DESCRIPTION
## Summary
https://github.com/ClickHouse/ch-go/issues/391
`time.Time`'s zero value when converted to Date and Date32 objects now equals 0 Unix time.

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
- [X] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
