### PR TITLE
fix(query): always close client.conn in cancelQuery (issue #405)

### DIFF
--- a/query.go
+++ b/query.go
@@ -36,16 +36,18 @@ func (c *Client) cancelQuery() error {
 		Buf: make([]byte, 1),
 	}
 	proto.ClientCodeCancel.Encode(&b)
+
+	var retErr error
 	if err := c.flushBuf(ctx, &b); err != nil {
-		return errors.Wrap(err, "flush")
+		retErr = errors.Join(retErr, errors.Wrap(err, "flush"))
 	}
 
-	// Closing connection to prevent further queries.
+	// Always close connection to prevent further queries.
 	if err := c.Close(); err != nil {
-		return errors.Wrap(err, "close")
+		retErr = errors.Join(retErr, errors.Wrap(err, "close"))
 	}
 
-	return nil
+	return retErr
 }
 
 func (c *Client) querySettings(q Query) []proto.Setting {


### PR DESCRIPTION
When the server closes the connection unexpectedly, the client will call cancelQuery (e.g. when client.packet fails). In client.cancelQuery, if client.flushBuf has data to flush, it will return a non-nil error and return early without calling conn.Close. This prevents the chpool from removing the client after client.Do and leaves the client.conn in a bad state such that future writes will always fail with a "broken pipe" error.

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
