### PR TITLE
feat(ch): use `writev` when possible

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,7 +29,6 @@ import (
 type Client struct {
 	lg       *zap.Logger
 	conn     net.Conn
-	buf      *proto.Buffer
 	writer   *proto.Writer
 	reader   *proto.Reader
 	info     proto.ClientHello
@@ -277,7 +276,7 @@ func (c *Client) flushBuf(ctx context.Context, b *proto.Buffer) error {
 	if n != len(b.Buf) {
 		return errors.Wrap(io.ErrShortWrite, "wrote less than expected")
 	}
-	if ce := c.lg.Check(zap.DebugLevel, "Flush"); ce != nil {
+	if ce := c.lg.Check(zap.DebugLevel, "Buffer flush"); ce != nil {
 		ce.Write(zap.Int("bytes", n))
 	}
 	b.Reset()
@@ -285,11 +284,30 @@ func (c *Client) flushBuf(ctx context.Context, b *proto.Buffer) error {
 }
 
 func (c *Client) flush(ctx context.Context) error {
-	return c.flushBuf(ctx, c.buf)
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, "context")
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := c.conn.SetWriteDeadline(deadline); err != nil {
+			return errors.Wrap(err, "set write deadline")
+		}
+		// Reset deadline.
+		defer func() { _ = c.conn.SetWriteDeadline(time.Time{}) }()
+	}
+	n, err := c.writer.Flush()
+	if err != nil {
+		return err
+	}
+	if ce := c.lg.Check(zap.DebugLevel, "Flush"); ce != nil {
+		ce.Write(zap.Int64("bytes", n))
+	}
+	return nil
 }
 
 func (c *Client) encode(v proto.AwareEncoder) {
-	v.EncodeAware(c.buf, c.protocolVersion)
+	c.writer.ChainBuffer(func(b *proto.Buffer) {
+		v.EncodeAware(b, c.protocolVersion)
+	})
 }
 
 //go:generate go run github.com/dmarkham/enumer -transform upper -type Compression -trimprefix Compression -output compression_enum.go
@@ -452,9 +470,32 @@ func Connect(ctx context.Context, conn net.Conn, opt Options) (*Client, error) {
 		ctx = newCtx
 		defer span.End()
 	}
+
+	var (
+		compressor        = compress.NewWriterWithLevel(compress.Level(opt.CompressionLevel))
+		compression       proto.Compression
+		compressionMethod compress.Method
+	)
+	switch opt.Compression {
+	case CompressionLZ4:
+		compression = proto.CompressionEnabled
+		compressionMethod = compress.LZ4
+	case CompressionLZ4HC:
+		compression = proto.CompressionEnabled
+		compressionMethod = compress.LZ4HC
+	case CompressionZSTD:
+		compression = proto.CompressionEnabled
+		compressionMethod = compress.ZSTD
+	case CompressionNone:
+		compression = proto.CompressionEnabled
+		compressionMethod = compress.None
+	default:
+		compression = proto.CompressionDisabled
+	}
+
 	c := &Client{
 		conn:     conn,
-		buf:      new(proto.Buffer),
+		writer:   proto.NewWriter(conn, new(proto.Buffer)),
 		reader:   proto.NewReader(conn),
 		settings: opt.Settings,
 		lg:       opt.Logger,
@@ -465,7 +506,9 @@ func Connect(ctx context.Context, conn net.Conn, opt Options) (*Client, error) {
 
 		readTimeout: opt.ReadTimeout,
 
-		compressor: compress.NewWriterWithLevel(compress.Level(opt.CompressionLevel)),
+		compression:       compression,
+		compressionMethod: compressionMethod,
+		compressor:        compressor,
 
 		version:         ver,
 		protocolVersion: opt.ProtocolVersion,
@@ -480,27 +523,6 @@ func Connect(ctx context.Context, conn net.Conn, opt Options) (*Client, error) {
 			User:     opt.User,
 			Password: opt.Password,
 		},
-	}
-	switch opt.Compression {
-	case CompressionLZ4:
-		c.compression = proto.CompressionEnabled
-		c.compressionMethod = compress.LZ4
-	case CompressionLZ4HC:
-		c.compression = proto.CompressionEnabled
-		c.compressionMethod = compress.LZ4HC
-	case CompressionZSTD:
-		c.compression = proto.CompressionEnabled
-		c.compressionMethod = compress.ZSTD
-	case CompressionNone:
-		c.compression = proto.CompressionEnabled
-		c.compressionMethod = compress.None
-	default:
-		c.compression = proto.CompressionDisabled
-	}
-
-	if _, ok := conn.(*net.TCPConn); writevAvailable && // writev available only on Unix platforms.
-		ok && c.compression == proto.CompressionDisabled { // Could not be used with TLS and compression.
-		c.writer = proto.NewWriter(c.conn, c.buf)
 	}
 
 	handshakeCtx, cancel := context.WithTimeout(ctx, opt.HandshakeTimeout)

--- a/handshake.go
+++ b/handshake.go
@@ -15,7 +15,9 @@ import (
 
 func (c *Client) encodeAddendum() {
 	if proto.FeatureQuotaKey.In(c.protocolVersion) {
-		c.buf.PutString(c.quotaKey)
+		c.writer.ChainBuffer(func(b *proto.Buffer) {
+			b.PutString(c.quotaKey)
+		})
 	}
 }
 
@@ -45,8 +47,9 @@ func (c *Client) handshake(ctx context.Context) error {
 	wg.Go(func() error {
 		defer cancel()
 
-		c.buf.Reset()
-		c.info.Encode(c.buf)
+		c.writer.ChainBuffer(func(b *proto.Buffer) {
+			c.info.Encode(b)
+		})
 		if err := c.flush(wgCtx); err != nil {
 			return errors.Wrap(err, "flush")
 		}

--- a/insert_bench_test.go
+++ b/insert_bench_test.go
@@ -1,0 +1,66 @@
+package ch
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-faster/errors"
+
+	"github.com/ClickHouse/ch-go/cht"
+	"github.com/ClickHouse/ch-go/proto"
+)
+
+func BenchmarkInsert(b *testing.B) {
+	cht.Skip(b)
+	srv := cht.New(b)
+
+	bench := func(rows int) func(b *testing.B) {
+		return func(b *testing.B) {
+			ctx := context.Background()
+			c, err := Dial(ctx, Options{
+				Address:     srv.TCP,
+				Compression: CompressionDisabled,
+			})
+			if err != nil {
+				b.Fatal(errors.Wrap(err, "dial"))
+			}
+			defer func() { _ = c.Close() }()
+
+			if err := c.Do(ctx, Query{
+				Body: "CREATE TABLE IF NOT EXISTS test_table (id Int64) ENGINE = Null",
+			}); err != nil {
+				b.Fatal(err)
+			}
+
+			var id proto.ColInt64
+			for i := 0; i < rows; i++ {
+				id = append(id, 1)
+			}
+
+			b.SetBytes(int64(rows) * 8)
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				if err := c.Do(ctx, Query{
+					Body: "INSERT INTO test_table VALUES",
+					Input: []proto.InputColumn{
+						{Name: "id", Data: id},
+					},
+				}); err != nil {
+					b.Fatal()
+				}
+			}
+		}
+	}
+	for _, rows := range []int{
+		10_000,
+		100_000,
+		1_000_000,
+		10_000_000,
+		100_000_000,
+	} {
+		b.Run(fmt.Sprintf("Rows%d", rows), bench(rows))
+	}
+}

--- a/ping.go
+++ b/ping.go
@@ -36,7 +36,9 @@ func (c *Client) Ping(ctx context.Context) (err error) {
 			span.End()
 		}()
 	}
-	c.buf.Encode(proto.ClientCodePing)
+	c.writer.ChainBuffer(func(b *proto.Buffer) {
+		b.Encode(proto.ClientCodePing)
+	})
 	if err := c.flush(ctx); err != nil {
 		return errors.Wrap(err, "flush")
 	}

--- a/proto/cmd/ch-gen-col/safe.go.tmpl
+++ b/proto/cmd/ch-gen-col/safe.go.tmpl
@@ -118,3 +118,11 @@ func (c {{ .Type }}) EncodeColumn(b *Buffer) {
 	}
 	{{- end }}
 }
+
+func (c {{ .Type }}) WriteColumn(w *Writer) {
+	{{- if .Byte }}
+		w.ChainWrite([]byte(c))
+	{{- else }}
+		w.ChainBuffer(c.EncodeColumn)
+	{{- end }}
+}

--- a/proto/cmd/ch-gen-col/test.go.tmpl
+++ b/proto/cmd/ch-gen-col/test.go.tmpl
@@ -75,6 +75,7 @@ func Test{{ .Type }}_DecodeColumn(t *testing.T) {
 		var v {{ .Type }}
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 
 {{- if not .Time }}

--- a/proto/cmd/ch-gen-col/unsafe.go.tmpl
+++ b/proto/cmd/ch-gen-col/unsafe.go.tmpl
@@ -68,3 +68,32 @@ func (c {{ .Type }}) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c {{ .Type }}) WriteColumn(w *Writer) {
+	{{- if .DateTime }}
+	v := c.Data
+	{{- else }}
+	v := c
+	{{- end }}
+	if len(v) == 0 {
+		return
+	}
+	{{- if .SingleByte }}
+		src := *(*[]byte)(unsafe.Pointer(&v))
+	{{- else }}
+		{{- if .FixedStr }}
+			const size = {{ .Bytes }}
+		{{- else }}
+			const size = {{ .Bits }} / 8
+		{{- end }}
+
+		s := *(*slice)(unsafe.Pointer(&v))
+		{{- if not .SingleByte }}
+			s.Len *= size
+			s.Cap *= size
+		{{- end }}
+
+		src := *(*[]byte)(unsafe.Pointer(&s))
+	{{- end }}
+	w.ChainWrite(src)
+}

--- a/proto/col_arr.go
+++ b/proto/col_arr.go
@@ -130,6 +130,12 @@ func (c ColArr[T]) EncodeColumn(b *Buffer) {
 	c.Data.EncodeColumn(b)
 }
 
+// WriteColumn implements ColInput.
+func (c ColArr[T]) WriteColumn(w *Writer) {
+	c.Offsets.WriteColumn(w)
+	c.Data.WriteColumn(w)
+}
+
 // Append appends new row to column.
 func (c *ColArr[T]) Append(v []T) {
 	c.Data.AppendArr(v)

--- a/proto/col_arr_test.go
+++ b/proto/col_arr_test.go
@@ -23,6 +23,7 @@ func testColumn[T any](t *testing.T, name string, f func() ColumnOf[T], values .
 	t.Run("Golden", func(t *testing.T) {
 		gold.Bytes(t, buf.Buf, "column_of_"+name)
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 	t.Run("Ok", func(t *testing.T) {
 		br := bytes.NewReader(buf.Buf)
 		r := NewReader(br)
@@ -84,6 +85,7 @@ func TestColArrOfStr(t *testing.T) {
 		dec := (&ColStr{}).Array()
 		requireNoShortRead(t, buf.Buf, colAware(dec, col.Rows()))
 	})
+	t.Run("WriteColumn", checkWriteColumn(col))
 }
 
 func TestArrOfLowCordStr(t *testing.T) {
@@ -118,6 +120,7 @@ func TestArrOfLowCordStr(t *testing.T) {
 		dec := NewArray[string](new(ColStr).LowCardinality())
 		requireNoShortRead(t, buf.Buf, colAware(dec, col.Rows()))
 	})
+	t.Run("WriteColumn", checkWriteColumn(col))
 }
 
 func TestColArr_DecodeColumn(t *testing.T) {

--- a/proto/col_auto.go
+++ b/proto/col_auto.go
@@ -122,3 +122,7 @@ func (c ColAuto) Reset() {
 func (c ColAuto) EncodeColumn(b *Buffer) {
 	c.Data.EncodeColumn(b)
 }
+
+func (c ColAuto) WriteColumn(w *Writer) {
+	c.Data.WriteColumn(w)
+}

--- a/proto/col_bool_safe.go
+++ b/proto/col_bool_safe.go
@@ -42,3 +42,11 @@ func (c *ColBool) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// WriteColumn encodes ColBool rows to *Writer.
+func (c ColBool) WriteColumn(w *Writer) {
+	if len(c) == 0 {
+		return
+	}
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_bool_test.go
+++ b/proto/col_bool_test.go
@@ -44,6 +44,7 @@ func TestColBool_DecodeColumn(t *testing.T) {
 		var dec ColBool
 		requireNoShortRead(t, buf.Buf, colAware(&dec, rows))
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 
 func BenchmarkColBool_DecodeColumn(b *testing.B) {

--- a/proto/col_bool_unsafe.go
+++ b/proto/col_bool_unsafe.go
@@ -34,3 +34,13 @@ func (c *ColBool) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// WriteColumn writes Bool rows to *Writer.
+func (c ColBool) WriteColumn(w *Writer) {
+	if len(c) == 0 {
+		return
+	}
+	s := *(*slice)(unsafe.Pointer(&c))    // #nosec G103
+	src := *(*[]byte)(unsafe.Pointer(&s)) // #nosec G103
+	w.ChainWrite(src)
+}

--- a/proto/col_date32_gen_test.go
+++ b/proto/col_date32_gen_test.go
@@ -58,6 +58,7 @@ func TestColDate32_DecodeColumn(t *testing.T) {
 		var v ColDate32
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 
 func BenchmarkColDate32_DecodeColumn(b *testing.B) {

--- a/proto/col_date32_safe_gen.go
+++ b/proto/col_date32_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColDate32) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColDate32) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_date32_unsafe_gen.go
+++ b/proto/col_date32_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColDate32) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColDate32) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 32 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_date_gen_test.go
+++ b/proto/col_date_gen_test.go
@@ -58,6 +58,7 @@ func TestColDate_DecodeColumn(t *testing.T) {
 		var v ColDate
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 
 func BenchmarkColDate_DecodeColumn(b *testing.B) {

--- a/proto/col_date_safe_gen.go
+++ b/proto/col_date_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColDate) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColDate) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_date_unsafe_gen.go
+++ b/proto/col_date_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColDate) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColDate) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 16 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_datetime64_gen_test.go
+++ b/proto/col_datetime64_gen_test.go
@@ -58,6 +58,7 @@ func TestColDateTime64_DecodeColumn(t *testing.T) {
 		var v ColDateTime64
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 
 func BenchmarkColDateTime64_DecodeColumn(b *testing.B) {

--- a/proto/col_datetime64_safe_gen.go
+++ b/proto/col_datetime64_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColDateTime64) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColDateTime64) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_datetime64_unsafe_gen.go
+++ b/proto/col_datetime64_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColDateTime64) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColDateTime64) WriteColumn(w *Writer) {
+	v := c.Data
+	if len(v) == 0 {
+		return
+	}
+	const size = 64 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_datetime_gen_test.go
+++ b/proto/col_datetime_gen_test.go
@@ -58,6 +58,7 @@ func TestColDateTime_DecodeColumn(t *testing.T) {
 		var v ColDateTime
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 
 func BenchmarkColDateTime_DecodeColumn(b *testing.B) {

--- a/proto/col_datetime_safe_gen.go
+++ b/proto/col_datetime_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColDateTime) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColDateTime) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_datetime_unsafe_gen.go
+++ b/proto/col_datetime_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColDateTime) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColDateTime) WriteColumn(w *Writer) {
+	v := c.Data
+	if len(v) == 0 {
+		return
+	}
+	const size = 32 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_decimal128_gen_test.go
+++ b/proto/col_decimal128_gen_test.go
@@ -62,6 +62,7 @@ func TestColDecimal128_DecodeColumn(t *testing.T) {
 		var v ColDecimal128
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColDecimal128Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_decimal128_safe_gen.go
+++ b/proto/col_decimal128_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColDecimal128) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColDecimal128) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_decimal128_unsafe_gen.go
+++ b/proto/col_decimal128_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColDecimal128) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColDecimal128) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 128 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_decimal256_gen_test.go
+++ b/proto/col_decimal256_gen_test.go
@@ -62,6 +62,7 @@ func TestColDecimal256_DecodeColumn(t *testing.T) {
 		var v ColDecimal256
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColDecimal256Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_decimal256_safe_gen.go
+++ b/proto/col_decimal256_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColDecimal256) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColDecimal256) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_decimal256_unsafe_gen.go
+++ b/proto/col_decimal256_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColDecimal256) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColDecimal256) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 256 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_decimal32_gen_test.go
+++ b/proto/col_decimal32_gen_test.go
@@ -62,6 +62,7 @@ func TestColDecimal32_DecodeColumn(t *testing.T) {
 		var v ColDecimal32
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColDecimal32Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_decimal32_safe_gen.go
+++ b/proto/col_decimal32_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColDecimal32) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColDecimal32) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_decimal32_unsafe_gen.go
+++ b/proto/col_decimal32_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColDecimal32) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColDecimal32) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 32 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_decimal64_gen_test.go
+++ b/proto/col_decimal64_gen_test.go
@@ -62,6 +62,7 @@ func TestColDecimal64_DecodeColumn(t *testing.T) {
 		var v ColDecimal64
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColDecimal64Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_decimal64_safe_gen.go
+++ b/proto/col_decimal64_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColDecimal64) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColDecimal64) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_decimal64_unsafe_gen.go
+++ b/proto/col_decimal64_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColDecimal64) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColDecimal64) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 64 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_enum.go
+++ b/proto/col_enum.go
@@ -169,4 +169,8 @@ func (e *ColEnum) EncodeColumn(b *Buffer) {
 	e.raw().EncodeColumn(b)
 }
 
+func (e *ColEnum) WriteColumn(w *Writer) {
+	e.raw().WriteColumn(w)
+}
+
 func (e *ColEnum) Type() ColumnType { return e.t }

--- a/proto/col_enum16_gen_test.go
+++ b/proto/col_enum16_gen_test.go
@@ -62,6 +62,7 @@ func TestColEnum16_DecodeColumn(t *testing.T) {
 		var v ColEnum16
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColEnum16Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_enum16_safe_gen.go
+++ b/proto/col_enum16_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColEnum16) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColEnum16) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_enum16_unsafe_gen.go
+++ b/proto/col_enum16_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColEnum16) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColEnum16) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 16 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_enum8_gen_test.go
+++ b/proto/col_enum8_gen_test.go
@@ -62,6 +62,7 @@ func TestColEnum8_DecodeColumn(t *testing.T) {
 		var v ColEnum8
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColEnum8Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_enum8_safe_gen.go
+++ b/proto/col_enum8_safe_gen.go
@@ -42,3 +42,7 @@ func (c ColEnum8) EncodeColumn(b *Buffer) {
 		b.Buf[i+start] = uint8(v[i])
 	}
 }
+
+func (c ColEnum8) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_enum8_unsafe_gen.go
+++ b/proto/col_enum8_unsafe_gen.go
@@ -37,3 +37,12 @@ func (c ColEnum8) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColEnum8) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	src := *(*[]byte)(unsafe.Pointer(&v))
+	w.ChainWrite(src)
+}

--- a/proto/col_fixed_str.go
+++ b/proto/col_fixed_str.go
@@ -86,6 +86,11 @@ func (c *ColFixedStr) DecodeColumn(r *Reader, rows int) error {
 	return nil
 }
 
+// WriteColumn writes ColFixedStr rows to *Writer.
+func (c ColFixedStr) WriteColumn(w *Writer) {
+	w.ChainWrite(c.Buf)
+}
+
 // Array returns new Array(FixedString).
 func (c *ColFixedStr) Array() *ColArr[[]byte] {
 	return &ColArr[[]byte]{

--- a/proto/col_fixed_str_test.go
+++ b/proto/col_fixed_str_test.go
@@ -86,6 +86,7 @@ func TestColFixedStr_EncodeColumn(t *testing.T) {
 			require.Equal(t, 10, v.Size)
 		})
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 
 func BenchmarkColFixedStr_DecodeColumn(b *testing.B) {

--- a/proto/col_fixedstr128_gen_test.go
+++ b/proto/col_fixedstr128_gen_test.go
@@ -66,6 +66,7 @@ func TestColFixedStr128_DecodeColumn(t *testing.T) {
 		var v ColFixedStr128
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColFixedStr128Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_fixedstr128_safe_gen.go
+++ b/proto/col_fixedstr128_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColFixedStr128) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColFixedStr128) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_fixedstr128_unsafe_gen.go
+++ b/proto/col_fixedstr128_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColFixedStr128) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColFixedStr128) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 128
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_fixedstr16_gen_test.go
+++ b/proto/col_fixedstr16_gen_test.go
@@ -66,6 +66,7 @@ func TestColFixedStr16_DecodeColumn(t *testing.T) {
 		var v ColFixedStr16
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColFixedStr16Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_fixedstr16_safe_gen.go
+++ b/proto/col_fixedstr16_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColFixedStr16) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColFixedStr16) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_fixedstr16_unsafe_gen.go
+++ b/proto/col_fixedstr16_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColFixedStr16) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColFixedStr16) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 16
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_fixedstr256_gen_test.go
+++ b/proto/col_fixedstr256_gen_test.go
@@ -66,6 +66,7 @@ func TestColFixedStr256_DecodeColumn(t *testing.T) {
 		var v ColFixedStr256
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColFixedStr256Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_fixedstr256_safe_gen.go
+++ b/proto/col_fixedstr256_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColFixedStr256) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColFixedStr256) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_fixedstr256_unsafe_gen.go
+++ b/proto/col_fixedstr256_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColFixedStr256) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColFixedStr256) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 256
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_fixedstr32_gen_test.go
+++ b/proto/col_fixedstr32_gen_test.go
@@ -66,6 +66,7 @@ func TestColFixedStr32_DecodeColumn(t *testing.T) {
 		var v ColFixedStr32
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColFixedStr32Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_fixedstr32_safe_gen.go
+++ b/proto/col_fixedstr32_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColFixedStr32) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColFixedStr32) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_fixedstr32_unsafe_gen.go
+++ b/proto/col_fixedstr32_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColFixedStr32) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColFixedStr32) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 32
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_fixedstr512_gen_test.go
+++ b/proto/col_fixedstr512_gen_test.go
@@ -66,6 +66,7 @@ func TestColFixedStr512_DecodeColumn(t *testing.T) {
 		var v ColFixedStr512
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColFixedStr512Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_fixedstr512_safe_gen.go
+++ b/proto/col_fixedstr512_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColFixedStr512) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColFixedStr512) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_fixedstr512_unsafe_gen.go
+++ b/proto/col_fixedstr512_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColFixedStr512) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColFixedStr512) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 512
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_fixedstr64_gen_test.go
+++ b/proto/col_fixedstr64_gen_test.go
@@ -66,6 +66,7 @@ func TestColFixedStr64_DecodeColumn(t *testing.T) {
 		var v ColFixedStr64
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColFixedStr64Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_fixedstr64_safe_gen.go
+++ b/proto/col_fixedstr64_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColFixedStr64) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColFixedStr64) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_fixedstr64_unsafe_gen.go
+++ b/proto/col_fixedstr64_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColFixedStr64) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColFixedStr64) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 64
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_fixedstr8_gen_test.go
+++ b/proto/col_fixedstr8_gen_test.go
@@ -66,6 +66,7 @@ func TestColFixedStr8_DecodeColumn(t *testing.T) {
 		var v ColFixedStr8
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColFixedStr8Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_fixedstr8_safe_gen.go
+++ b/proto/col_fixedstr8_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColFixedStr8) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColFixedStr8) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_fixedstr8_unsafe_gen.go
+++ b/proto/col_fixedstr8_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColFixedStr8) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColFixedStr8) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_float32_gen_test.go
+++ b/proto/col_float32_gen_test.go
@@ -62,6 +62,7 @@ func TestColFloat32_DecodeColumn(t *testing.T) {
 		var v ColFloat32
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColFloat32Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_float32_safe_gen.go
+++ b/proto/col_float32_safe_gen.go
@@ -54,3 +54,7 @@ func (c ColFloat32) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColFloat32) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_float32_unsafe_gen.go
+++ b/proto/col_float32_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColFloat32) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColFloat32) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 32 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_float64_gen_test.go
+++ b/proto/col_float64_gen_test.go
@@ -62,6 +62,7 @@ func TestColFloat64_DecodeColumn(t *testing.T) {
 		var v ColFloat64
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColFloat64Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_float64_safe_gen.go
+++ b/proto/col_float64_safe_gen.go
@@ -54,3 +54,7 @@ func (c ColFloat64) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColFloat64) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_float64_unsafe_gen.go
+++ b/proto/col_float64_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColFloat64) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColFloat64) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 64 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_int128_gen_test.go
+++ b/proto/col_int128_gen_test.go
@@ -62,6 +62,7 @@ func TestColInt128_DecodeColumn(t *testing.T) {
 		var v ColInt128
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColInt128Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_int128_safe_gen.go
+++ b/proto/col_int128_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColInt128) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColInt128) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_int128_unsafe_gen.go
+++ b/proto/col_int128_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColInt128) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColInt128) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 128 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_int16_gen_test.go
+++ b/proto/col_int16_gen_test.go
@@ -62,6 +62,7 @@ func TestColInt16_DecodeColumn(t *testing.T) {
 		var v ColInt16
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColInt16Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_int16_safe_gen.go
+++ b/proto/col_int16_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColInt16) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColInt16) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_int16_unsafe_gen.go
+++ b/proto/col_int16_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColInt16) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColInt16) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 16 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_int256_gen_test.go
+++ b/proto/col_int256_gen_test.go
@@ -62,6 +62,7 @@ func TestColInt256_DecodeColumn(t *testing.T) {
 		var v ColInt256
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColInt256Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_int256_safe_gen.go
+++ b/proto/col_int256_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColInt256) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColInt256) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_int256_unsafe_gen.go
+++ b/proto/col_int256_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColInt256) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColInt256) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 256 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_int32_gen_test.go
+++ b/proto/col_int32_gen_test.go
@@ -62,6 +62,7 @@ func TestColInt32_DecodeColumn(t *testing.T) {
 		var v ColInt32
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColInt32Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_int32_safe_gen.go
+++ b/proto/col_int32_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColInt32) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColInt32) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_int32_unsafe_gen.go
+++ b/proto/col_int32_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColInt32) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColInt32) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 32 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_int64_gen_test.go
+++ b/proto/col_int64_gen_test.go
@@ -62,6 +62,7 @@ func TestColInt64_DecodeColumn(t *testing.T) {
 		var v ColInt64
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColInt64Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_int64_safe_gen.go
+++ b/proto/col_int64_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColInt64) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColInt64) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_int64_unsafe_gen.go
+++ b/proto/col_int64_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColInt64) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColInt64) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 64 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_int8_gen_test.go
+++ b/proto/col_int8_gen_test.go
@@ -62,6 +62,7 @@ func TestColInt8_DecodeColumn(t *testing.T) {
 		var v ColInt8
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColInt8Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_int8_safe_gen.go
+++ b/proto/col_int8_safe_gen.go
@@ -42,3 +42,7 @@ func (c ColInt8) EncodeColumn(b *Buffer) {
 		b.Buf[i+start] = uint8(v[i])
 	}
 }
+
+func (c ColInt8) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_int8_unsafe_gen.go
+++ b/proto/col_int8_unsafe_gen.go
@@ -37,3 +37,12 @@ func (c ColInt8) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColInt8) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	src := *(*[]byte)(unsafe.Pointer(&v))
+	w.ChainWrite(src)
+}

--- a/proto/col_interval.go
+++ b/proto/col_interval.go
@@ -110,3 +110,7 @@ func (c *ColInterval) Reset() {
 func (c ColInterval) EncodeColumn(b *Buffer) {
 	c.Values.EncodeColumn(b)
 }
+
+func (c ColInterval) WriteColumn(w *Writer) {
+	c.Values.WriteColumn(w)
+}

--- a/proto/col_interval_test.go
+++ b/proto/col_interval_test.go
@@ -132,4 +132,5 @@ func TestColInterval(t *testing.T) {
 		var v ColInterval
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }

--- a/proto/col_ipv4_gen_test.go
+++ b/proto/col_ipv4_gen_test.go
@@ -62,6 +62,7 @@ func TestColIPv4_DecodeColumn(t *testing.T) {
 		var v ColIPv4
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColIPv4Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_ipv4_safe_gen.go
+++ b/proto/col_ipv4_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColIPv4) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColIPv4) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_ipv4_unsafe_gen.go
+++ b/proto/col_ipv4_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColIPv4) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColIPv4) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 32 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_ipv6_gen_test.go
+++ b/proto/col_ipv6_gen_test.go
@@ -62,6 +62,7 @@ func TestColIPv6_DecodeColumn(t *testing.T) {
 		var v ColIPv6
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColIPv6Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_ipv6_safe_gen.go
+++ b/proto/col_ipv6_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColIPv6) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColIPv6) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_ipv6_unsafe_gen.go
+++ b/proto/col_ipv6_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColIPv6) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColIPv6) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 128 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_low_cardinality_raw_test.go
+++ b/proto/col_low_cardinality_raw_test.go
@@ -60,6 +60,7 @@ func TestColLowCardinalityRaw_DecodeColumn(t *testing.T) {
 			}
 			requireNoShortRead(t, buf.Buf, colAware(dec, rows))
 		})
+		t.Run("WriteColumn", checkWriteColumn(col))
 	})
 	t.Run("Blank", func(t *testing.T) {
 		// Blank columns (i.e. row count is zero) are not encoded.

--- a/proto/col_low_cardinality_test.go
+++ b/proto/col_low_cardinality_test.go
@@ -93,6 +93,7 @@ func TestArrLowCardinalityStr(t *testing.T) {
 		dec := new(ColStr).LowCardinality().Array()
 		requireNoShortRead(t, buf.Buf, colAware(dec, rows))
 	})
+	t.Run("WriteColumn", checkWriteColumn(col))
 }
 
 func TestColLowCardinality_DecodeColumn(t *testing.T) {

--- a/proto/col_map.go
+++ b/proto/col_map.go
@@ -164,6 +164,16 @@ func (c ColMap[K, V]) EncodeColumn(b *Buffer) {
 	c.Values.EncodeColumn(b)
 }
 
+func (c ColMap[K, V]) WriteColumn(w *Writer) {
+	if c.Rows() == 0 {
+		return
+	}
+
+	c.Offsets.WriteColumn(w)
+	c.Keys.WriteColumn(w)
+	c.Values.WriteColumn(w)
+}
+
 // Prepare ensures Preparable column propagation.
 func (c ColMap[K, V]) Prepare() error {
 	if v, ok := c.Keys.(Preparable); ok {

--- a/proto/col_nothing.go
+++ b/proto/col_nothing.go
@@ -71,3 +71,7 @@ func (c ColNothing) EncodeColumn(b *Buffer) {
 	}
 	b.PutRaw(make([]byte, c))
 }
+
+func (c ColNothing) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_nothing_test.go
+++ b/proto/col_nothing_test.go
@@ -61,4 +61,5 @@ func TestColNothing(t *testing.T) {
 		var v ColNothing
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(ColNothing(0)))
 }

--- a/proto/col_nullable.go
+++ b/proto/col_nullable.go
@@ -127,6 +127,11 @@ func (c ColNullable[T]) EncodeColumn(b *Buffer) {
 	c.Values.EncodeColumn(b)
 }
 
+func (c ColNullable[T]) WriteColumn(w *Writer) {
+	c.Nulls.WriteColumn(w)
+	c.Values.WriteColumn(w)
+}
+
 func (c ColNullable[T]) IsElemNull(i int) bool {
 	if i < c.Rows() {
 		return c.Nulls[i] == boolTrue

--- a/proto/col_point.go
+++ b/proto/col_point.go
@@ -61,3 +61,8 @@ func (c ColPoint) EncodeColumn(b *Buffer) {
 	c.X.EncodeColumn(b)
 	c.Y.EncodeColumn(b)
 }
+
+func (c ColPoint) WriteColumn(w *Writer) {
+	c.X.WriteColumn(w)
+	c.Y.WriteColumn(w)
+}

--- a/proto/col_raw_of.go
+++ b/proto/col_raw_of.go
@@ -82,3 +82,17 @@ func (c *ColRawOf[X]) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// WriteColumn write ColRawOf rows to *Writer.
+func (c ColRawOf[X]) WriteColumn(w *Writer) {
+	if len(c) == 0 {
+		return
+	}
+	var x X
+	size := unsafe.Sizeof(x)           // #nosec G103
+	s := *(*slice)(unsafe.Pointer(&c)) // #nosec G103
+	s.Len *= size
+	s.Cap *= size
+	src := *(*[]byte)(unsafe.Pointer(&s)) // #nosec G103
+	w.ChainWrite(src)
+}

--- a/proto/col_str.go
+++ b/proto/col_str.go
@@ -76,6 +76,18 @@ func (c ColStr) EncodeColumn(b *Buffer) {
 	}
 }
 
+// WriteColumn writes String rows to *Writer.
+func (c ColStr) WriteColumn(w *Writer) {
+	buf := make([]byte, binary.MaxVarintLen64)
+	for _, p := range c.Pos {
+		w.ChainBuffer(func(b *Buffer) {
+			n := binary.PutUvarint(buf, uint64(p.End-p.Start))
+			b.PutRaw(buf[:n])
+		})
+		w.ChainWrite(c.Buf[p.Start:p.End])
+	}
+}
+
 // ForEach calls f on each string from column.
 func (c ColStr) ForEach(f func(i int, s string) error) error {
 	return c.ForEachBytes(func(i int, b []byte) error {

--- a/proto/col_tuple.go
+++ b/proto/col_tuple.go
@@ -167,3 +167,9 @@ func (c ColTuple) EncodeColumn(b *Buffer) {
 		v.EncodeColumn(b)
 	}
 }
+
+func (c ColTuple) WriteColumn(w *Writer) {
+	for _, v := range c {
+		v.WriteColumn(w)
+	}
+}

--- a/proto/col_uint128_gen_test.go
+++ b/proto/col_uint128_gen_test.go
@@ -62,6 +62,7 @@ func TestColUInt128_DecodeColumn(t *testing.T) {
 		var v ColUInt128
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColUInt128Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_uint128_safe_gen.go
+++ b/proto/col_uint128_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColUInt128) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColUInt128) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_uint128_unsafe_gen.go
+++ b/proto/col_uint128_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColUInt128) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColUInt128) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 128 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_uint16_gen_test.go
+++ b/proto/col_uint16_gen_test.go
@@ -62,6 +62,7 @@ func TestColUInt16_DecodeColumn(t *testing.T) {
 		var v ColUInt16
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColUInt16Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_uint16_safe_gen.go
+++ b/proto/col_uint16_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColUInt16) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColUInt16) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_uint16_unsafe_gen.go
+++ b/proto/col_uint16_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColUInt16) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColUInt16) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 16 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_uint256_gen_test.go
+++ b/proto/col_uint256_gen_test.go
@@ -62,6 +62,7 @@ func TestColUInt256_DecodeColumn(t *testing.T) {
 		var v ColUInt256
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColUInt256Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_uint256_safe_gen.go
+++ b/proto/col_uint256_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColUInt256) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColUInt256) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_uint256_unsafe_gen.go
+++ b/proto/col_uint256_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColUInt256) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColUInt256) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 256 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_uint32_gen_test.go
+++ b/proto/col_uint32_gen_test.go
@@ -62,6 +62,7 @@ func TestColUInt32_DecodeColumn(t *testing.T) {
 		var v ColUInt32
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColUInt32Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_uint32_safe_gen.go
+++ b/proto/col_uint32_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColUInt32) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColUInt32) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_uint32_unsafe_gen.go
+++ b/proto/col_uint32_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColUInt32) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColUInt32) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 32 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_uint64_gen_test.go
+++ b/proto/col_uint64_gen_test.go
@@ -62,6 +62,7 @@ func TestColUInt64_DecodeColumn(t *testing.T) {
 		var v ColUInt64
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColUInt64Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_uint64_safe_gen.go
+++ b/proto/col_uint64_safe_gen.go
@@ -53,3 +53,7 @@ func (c ColUInt64) EncodeColumn(b *Buffer) {
 		offset += size
 	}
 }
+
+func (c ColUInt64) WriteColumn(w *Writer) {
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_uint64_unsafe_gen.go
+++ b/proto/col_uint64_unsafe_gen.go
@@ -43,3 +43,18 @@ func (c ColUInt64) EncodeColumn(b *Buffer) {
 	dst := b.Buf[offset:]
 	copy(dst, src)
 }
+
+func (c ColUInt64) WriteColumn(w *Writer) {
+	v := c
+	if len(v) == 0 {
+		return
+	}
+	const size = 64 / 8
+
+	s := *(*slice)(unsafe.Pointer(&v))
+	s.Len *= size
+	s.Cap *= size
+
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	w.ChainWrite(src)
+}

--- a/proto/col_uint8_gen_test.go
+++ b/proto/col_uint8_gen_test.go
@@ -62,6 +62,7 @@ func TestColUInt8_DecodeColumn(t *testing.T) {
 		var v ColUInt8
 		v.EncodeColumn(nil) // should be no-op
 	})
+	t.Run("WriteColumn", checkWriteColumn(data))
 }
 func TestColUInt8Array(t *testing.T) {
 	const rows = 50

--- a/proto/col_uint8_safe_gen.go
+++ b/proto/col_uint8_safe_gen.go
@@ -31,3 +31,7 @@ func (c ColUInt8) EncodeColumn(b *Buffer) {
 	}
 	b.Buf = append(b.Buf, v...)
 }
+
+func (c ColUInt8) WriteColumn(w *Writer) {
+	w.ChainWrite([]byte(c))
+}

--- a/proto/col_uuid_safe.go
+++ b/proto/col_uuid_safe.go
@@ -34,3 +34,12 @@ func (c ColUUID) EncodeColumn(b *Buffer) {
 	}
 	bswap.Swap64(b.Buf) // BE <-> LE
 }
+
+// WriteColumn encodes ColUUID rows to *Writer.
+func (c ColUUID) WriteColumn(w *Writer) {
+	if len(c) == 0 {
+		return
+	}
+	// Can't write UUID as-is: bswap is required.
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/col_uuid_unsafe.go
+++ b/proto/col_uuid_unsafe.go
@@ -47,3 +47,12 @@ func (c ColUUID) EncodeColumn(b *Buffer) {
 	copy(dst, src)
 	bswap.Swap64(dst) // BE <-> LE
 }
+
+// WriteColumn encodes ColUUID rows to *Writer.
+func (c ColUUID) WriteColumn(w *Writer) {
+	if len(c) == 0 {
+		return
+	}
+	// Can't write UUID as-is: bswap is required.
+	w.ChainBuffer(c.EncodeColumn)
+}

--- a/proto/column.go
+++ b/proto/column.go
@@ -12,6 +12,7 @@ type ColInput interface {
 	Type() ColumnType
 	Rows() int
 	EncodeColumn(b *Buffer)
+	WriteColumn(w *Writer)
 }
 
 // ColResult column.

--- a/proto/column_test.go
+++ b/proto/column_test.go
@@ -1,6 +1,7 @@
 package proto
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,24 @@ func requireEqual[T any](t *testing.T, a, b ColumnOf[T]) {
 	require.Equal(t, a.Rows(), b.Rows(), "rows count should match")
 	for i := 0; i < a.Rows(); i++ {
 		require.Equalf(t, a.Row(i), b.Row(i), "[%d]", i)
+	}
+}
+
+func checkWriteColumn(data ColInput) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		var expect Buffer
+		data.EncodeColumn(&expect)
+
+		var (
+			got bytes.Buffer
+			w   = NewWriter(&got, new(Buffer))
+		)
+		data.WriteColumn(w)
+		require.NoError(t, w.Flush())
+
+		require.Equal(t, expect.Buf, got.Bytes())
 	}
 }
 

--- a/proto/column_test.go
+++ b/proto/column_test.go
@@ -28,7 +28,8 @@ func checkWriteColumn(data ColInput) func(*testing.T) {
 			w   = NewWriter(&got, new(Buffer))
 		)
 		data.WriteColumn(w)
-		require.NoError(t, w.Flush())
+		_, err := w.Flush()
+		require.NoError(t, err)
 
 		require.Equal(t, expect.Buf, got.Bytes())
 	}

--- a/proto/writer.go
+++ b/proto/writer.go
@@ -1,0 +1,82 @@
+package proto
+
+import (
+	"io"
+	"net"
+)
+
+// Writer is a column writer.
+//
+// It helps to reduce memory footprint by writing column using vector I/O.
+type Writer struct {
+	conn io.Writer
+
+	buf       *Buffer
+	bufOffset int
+	needCut   bool
+
+	vec net.Buffers
+}
+
+// NewWriter creates new [Writer].
+func NewWriter(conn io.Writer, buf *Buffer) *Writer {
+	w := &Writer{
+		conn: conn,
+		buf:  buf,
+		vec:  make(net.Buffers, 0, 16),
+	}
+	// In case if passed buf is not empty.
+	w.cutBuffer()
+	return w
+}
+
+// ChainWrite adds buffer to the vector to write later.
+//
+// Passed byte slice may be captured until [Writer.Flush] is called.
+func (w *Writer) ChainWrite(data []byte) {
+	if w.needCut {
+		w.cutBuffer()
+	}
+	w.vec = append(w.vec, data)
+}
+
+// ChainBuffer creates a temporary buffer and adds it to the vector to write later.
+//
+// Data is not written immediately, call [Writer.Flush] to flush data.
+//
+// NB: do not retain buffer.
+func (w *Writer) ChainBuffer(cb func(*Buffer)) {
+	cb(w.buf)
+	w.needCut = true
+}
+
+func (w *Writer) cutBuffer() {
+	w.needCut = false
+
+	newOffset := len(w.buf.Buf)
+	data := w.buf.Buf[w.bufOffset:newOffset:newOffset]
+	if len(data) == 0 {
+		return
+	}
+	w.bufOffset = newOffset
+	w.vec = append(w.vec, data)
+}
+
+func (w *Writer) reset() {
+	w.bufOffset = 0
+	w.needCut = false
+	w.buf.Reset()
+	// Do not hold references, to avoid memory leaks.
+	clear(w.vec)
+	w.vec = w.vec[:0]
+}
+
+// Flush flushes all data to writer.
+func (w *Writer) Flush() (err error) {
+	if w.needCut {
+		w.cutBuffer()
+	}
+	_, err = w.vec.WriteTo(w.conn)
+	w.reset()
+	return err
+}

--- a/writev_other.go
+++ b/writev_other.go
@@ -1,5 +1,0 @@
-//go:build !unix
-
-package ch
-
-const writevAvailable = false

--- a/writev_other.go
+++ b/writev_other.go
@@ -1,0 +1,5 @@
+//go:build !unix
+
+package ch
+
+const writevAvailable = false

--- a/writev_unix.go
+++ b/writev_unix.go
@@ -1,5 +1,0 @@
-//go:build unix
-
-package ch
-
-const writevAvailable = true

--- a/writev_unix.go
+++ b/writev_unix.go
@@ -1,0 +1,5 @@
+//go:build unix
+
+package ch
+
+const writevAvailable = true


### PR DESCRIPTION
Reduce memory footprint by avoiding unnecessary data copying during inserts.
```
goos: linux
goarch: amd64
pkg: github.com/ClickHouse/ch-go
cpu: AMD Ryzen 9 5950X 16-Core Processor            
                        │   old.txt    │               new.txt               │
                        │    sec/op    │   sec/op     vs base                │
Insert/Rows10000-32       396.3µ ±  6%   421.2µ ± 1%   +6.27% (p=0.000 n=15)
Insert/Rows100000-32      521.8µ ±  6%   687.5µ ± 1%  +31.76% (p=0.000 n=15)
Insert/Rows1000000-32     3.562m ± 12%   3.485m ± 1%        ~ (p=0.305 n=15)
Insert/Rows10000000-32    32.29m ±  3%   31.77m ± 2%   -1.61% (p=0.023 n=15)
Insert/Rows100000000-32   421.7m ±  6%   230.5m ± 9%  -45.35% (p=0.000 n=15)
geomean                   6.314m         5.939m        -5.93%

                        │    old.txt    │               new.txt                │
                        │      B/s      │     B/s       vs base                │
Insert/Rows10000-32       192.5Mi ±  7%   181.1Mi ± 1%   -5.90% (p=0.000 n=15)
Insert/Rows100000-32      1.428Gi ±  6%   1.084Gi ± 1%  -24.10% (p=0.000 n=15)
Insert/Rows1000000-32     2.092Gi ± 14%   2.138Gi ± 1%        ~ (p=0.305 n=15)
Insert/Rows10000000-32    2.307Gi ±  2%   2.345Gi ± 2%   +1.64% (p=0.023 n=15)
Insert/Rows100000000-32   1.767Gi ±  6%   3.233Gi ± 8%  +82.97% (p=0.000 n=15)
geomean                   1.180Gi         1.255Gi        +6.31%

                        │      old.txt      │                new.txt                │
                        │       B/op        │     B/op      vs base                 │
Insert/Rows10000-32           10.31Ki ±  0%   10.45Ki ± 0%    +1.42% (p=0.000 n=15)
Insert/Rows100000-32          10.64Ki ±  0%   10.66Ki ± 0%    +0.19% (p=0.000 n=15)
Insert/Rows1000000-32         32.03Ki ±  9%   10.94Ki ± 0%   -65.85% (p=0.000 n=15)
Insert/Rows10000000-32      2309.09Ki ±  8%   11.59Ki ± 0%   -99.50% (p=0.000 n=15)
Insert/Rows100000000-32   260431.62Ki ± 25%   12.43Ki ± 1%  -100.00% (p=0.000 n=15)
geomean                       291.7Ki         11.19Ki        -96.16%

                        │  old.txt   │              new.txt              │
                        │ allocs/op  │ allocs/op   vs base               │
Insert/Rows10000-32       325.0 ± 0%   328.0 ± 0%  +0.92% (p=0.000 n=15)
Insert/Rows100000-32      325.0 ± 0%   328.0 ± 0%  +0.92% (p=0.000 n=15)
Insert/Rows1000000-32     326.0 ± 0%   329.0 ± 0%  +0.92% (p=0.000 n=15)
Insert/Rows10000000-32    326.0 ± 0%   329.0 ± 0%  +0.92% (p=0.000 n=15)
Insert/Rows100000000-32   331.0 ± 0%   333.0 ± 0%  +0.60% (p=0.000 n=15)
geomean                   326.6        329.4       +0.86%
```