### PR TITLE
Fix client default read timeout setting

### DIFF
--- a/client.go
+++ b/client.go
@@ -411,9 +411,6 @@ func (o *Options) setDefaults() {
 	if o.ReadTimeout == 0 {
 		o.ReadTimeout = DefaultReadTimeout
 	}
-	if o.ReadTimeout < 0 || o.ReadTimeout == NoTimeout {
-		o.ReadTimeout = 0
-	}
 }
 
 type clientVersion struct {


### PR DESCRIPTION
## Summary
In this PR I removed setting zero timeout in case of passed negative value.
The problem occurs when we call `client.Dial`:
1. Firstly [here](https://github.com/ClickHouse/ch-go/blob/main/client.go#L520) we call dial and sets default options, and when the `ReadTimeout` value is `NoTimeout`, we set it to zero.
2. Then, in `client.Connect` method, we call `opt.setDefault` as well [here](https://github.com/ClickHouse/ch-go/blob/main/client.go#L429), but by this moment `readTimeout` had been already set to default value zero, and here it would be interpreted as time duration zero value and be set to `DefaultReadTimeout`.

To prevent this error it is sufficient just to remove setting `ReadTimeout` to zero and leave it with negative value, because [here](https://github.com/ClickHouse/ch-go/blob/main/client.go#L217) is the only place it is used and current check is enough.