### PR TITLE
use net.Buffers to reduce memory inuse bytes..

### DIFF
--- a/proto/block.go
+++ b/proto/block.go
@@ -178,14 +178,7 @@ func (b Block) EncodeRawBlock(buf *Buffer, version int, input []InputColumn) err
 		if v, ok := col.Data.(StateEncoder); ok {
 			v.EncodeState(buf)
 		}
-		if v, ok := col.Data.(*ColStr); ok {
-			// TODO SUPPORT OTHER COLUMN.
-			buf.Buffers = append(buf.Buffers, buf.Buf)
-			buf.Buf = nil
-			buf.Buffers = append(buf.Buffers, v.Buf)
-		} else {
-			col.Data.EncodeColumn(buf)
-		}
+		col.Data.EncodeColumn(buf)
 	}
 	return nil
 }

--- a/proto/block.go
+++ b/proto/block.go
@@ -178,7 +178,14 @@ func (b Block) EncodeRawBlock(buf *Buffer, version int, input []InputColumn) err
 		if v, ok := col.Data.(StateEncoder); ok {
 			v.EncodeState(buf)
 		}
-		col.Data.EncodeColumn(buf)
+		if v, ok := col.Data.(*ColStr); ok {
+			// TODO SUPPORT OTHER COLUMN.
+			buf.Buffers = append(buf.Buffers, buf.Buf)
+			buf.Buf = nil
+			buf.Buffers = append(buf.Buffers, v.Buf)
+		} else {
+			col.Data.EncodeColumn(buf)
+		}
 	}
 	return nil
 }

--- a/proto/buffer.go
+++ b/proto/buffer.go
@@ -5,11 +5,13 @@ import (
 	"encoding/binary"
 	"io"
 	"math"
+	"net"
 )
 
 // Buffer implements ClickHouse binary protocol encoding.
 type Buffer struct {
 	Buf []byte
+	net.Buffers
 }
 
 // Reader returns new *Reader from *Buffer.
@@ -45,6 +47,7 @@ func (b *Buffer) Encode(e Encoder) {
 // Reset buffer to zero length.
 func (b *Buffer) Reset() {
 	b.Buf = b.Buf[:0]
+	b.Buffers = nil
 }
 
 // Read implements io.Reader.

--- a/proto/col_str.go
+++ b/proto/col_str.go
@@ -21,6 +21,7 @@ type ColStr struct {
 
 // Append string to column.
 func (c *ColStr) Append(v string) {
+	c.Buf = binary.AppendUvarint(c.Buf, uint64(len(v)))
 	start := len(c.Buf)
 	c.Buf = append(c.Buf, v...)
 	end := len(c.Buf)
@@ -29,6 +30,7 @@ func (c *ColStr) Append(v string) {
 
 // AppendBytes append byte slice as string to column.
 func (c *ColStr) AppendBytes(v []byte) {
+	c.Buf = binary.AppendUvarint(c.Buf, uint64(len(v)))
 	start := len(c.Buf)
 	c.Buf = append(c.Buf, v...)
 	end := len(c.Buf)

--- a/proto/col_str.go
+++ b/proto/col_str.go
@@ -70,12 +70,11 @@ func (c *ColStr) Reset() {
 
 // EncodeColumn encodes String rows to *Buffer.
 func (c ColStr) EncodeColumn(b *Buffer) {
-	buf := make([]byte, binary.MaxVarintLen64)
-	for _, p := range c.Pos {
-		n := binary.PutUvarint(buf, uint64(p.End-p.Start))
-		b.Buf = append(b.Buf, buf[:n]...)
-		b.Buf = append(b.Buf, c.Buf[p.Start:p.End]...)
+	if b.Buf != nil {
+		b.Buffers = append(b.Buffers, b.Buf)
+		b.Buf = nil
 	}
+	b.Buffers = append(b.Buffers, c.Buf)
 }
 
 // ForEach calls f on each string from column.

--- a/query.go
+++ b/query.go
@@ -301,6 +301,7 @@ func (c *Client) encodeBlock(ctx context.Context, tableName string, input []prot
 	// Note: only blocks are compressed.
 	// See "Compressible" method of server or client code for reference.
 	if c.compression == proto.CompressionEnabled {
+		// TODO SUPPORT COMPRESS
 		data := c.buf.Buf[start:]
 		if err := c.compressor.Compress(c.compressionMethod, data); err != nil {
 			return errors.Wrap(err, "compress")


### PR DESCRIPTION
## Summary
use net.Buffers to reduce memory inuse bytes

## Detail
In a typical clickhouse insert scenario, in order to improve the insert efficiency, the client usually inserts in batches, inserting every 10w:
```
1, convert []struct to proto.Input
2, use ch.Client.Do to convert proto.Input to proto.Block
3, send proto.Block to clickhouse server.
```
The third step usually takes a long time, so in order to reduce memory usage, you can set []struct to nil after the first step to release []struct.

Since proto.Block is []byte, the proto.Input data will actually be copied to proto.Block, which results in double memory overhead.

Now set proto.Block to net.Buffers, which allows a series of memory areas to be written to the network connection at once, reducing the memory overhead by half.

Only Support *Col.Str for now.
## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
