### PR TITLE
fix/query: must reset buf in Do.

### DIFF
--- a/query.go
+++ b/query.go
@@ -572,6 +572,7 @@ func (c *Client) handlePacket(ctx context.Context, p proto.ServerCode, q Query) 
 
 // Do performs Query on ClickHouse server.
 func (c *Client) Do(ctx context.Context, q Query) (err error) {
+	defer c.buf.Reset() // reset buf.
 	if c.IsClosed() {
 		return ErrClosed
 	}


### PR DESCRIPTION
## Summary
must reset buf in Do.

func flushBuf only reset buf if flush succeed.

so if flush buf failed, the next Do would send the last Do's proto.Block.
