### PR TITLE
Fix typo in README

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,8 @@ linters-settings:
     excludes:
       - G115 # Annoying and have a lot of false-positive results.
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
   gocyclo:
     min-complexity: 15
   maligned:

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ _, _ = out.Write(buf.Buf)
 // To do this, reset buf and all columns, append new values
 // to columns and call EncodeRawBlock again.
 buf.Reset()
-colV.Reset()
+colK.Reset()
 colV.Reset()
 ```
 


### PR DESCRIPTION
Also fix lint warning:
WARN [config_reader] The configuration option `linters.govet.check-shadowing` is deprecated. Please enable `shadow` instead, if you are not using `enable-all`.