### PR TITLE
feat: infer Decimal

### DIFF
--- a/proto/col_auto_test.go
+++ b/proto/col_auto_test.go
@@ -46,6 +46,17 @@ func TestColAuto_Infer(t *testing.T) {
 		ColumnTypeUUID,
 		ColumnTypeArray.Sub(ColumnTypeUUID),
 		ColumnTypeNullable.Sub(ColumnTypeUUID),
+		ColumnTypeDecimal,
+		ColumnTypeDecimal32,
+		ColumnTypeDecimal64,
+		ColumnTypeDecimal128,
+		ColumnTypeDecimal256,
+		"Decimal(2)",
+		"Decimal(20, 2)",
+		"Decimal32(1)",
+		"Decimal64(2)",
+		"Decimal128(3)",
+		"Decimal256(4)",
 	} {
 		r := AutoResult("foo")
 		require.NoError(t, r.Data.(Inferable).Infer(columnType))

--- a/proto/column.go
+++ b/proto/column.go
@@ -207,6 +207,7 @@ const (
 	ColumnTypeBool           ColumnType = "Bool"
 	ColumnTypeTuple          ColumnType = "Tuple"
 	ColumnTypeNullable       ColumnType = "Nullable"
+	ColumnTypeDecimal        ColumnType = "Decimal"
 	ColumnTypeDecimal32      ColumnType = "Decimal32"
 	ColumnTypeDecimal64      ColumnType = "Decimal64"
 	ColumnTypeDecimal128     ColumnType = "Decimal128"


### PR DESCRIPTION
[relevant docs](https://clickhouse.com/docs/en/sql-reference/data-types/decimal)

Infer `Decimal(P, S)` to its subtype. Ignore scale

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG