### PR TITLE
fix: column type conflicts

### DIFF
--- a/proto/column_test.go
+++ b/proto/column_test.go
@@ -60,9 +60,14 @@ func TestColumnType_Elem(t *testing.T) {
 				{A: "Map(String,String)", B: "Map(String, String)"},
 				{A: "Enum8('increment' = 1, 'gauge' = 2)", B: "Int8"},
 				{A: "Int8", B: "Enum8('increment' = 1, 'gauge' = 2)"},
+				{A: "Decimal256", B: "Decimal(76, 38)"},
+				{A: "Nullable(Decimal256)", B: "Nullable(Decimal(76, 38))"},
 			} {
 				assert.False(t, tt.A.Conflicts(tt.B),
 					"%s ~ %s", tt.A, tt.B,
+				)
+				assert.False(t, tt.B.Conflicts(tt.A),
+					"%s ~ %s", tt.B, tt.A,
 				)
 			}
 		})
@@ -79,6 +84,9 @@ func TestColumnType_Elem(t *testing.T) {
 			} {
 				assert.True(t, tt.A.Conflicts(tt.B),
 					"%s !~ %s", tt.A, tt.B,
+				)
+				assert.True(t, tt.B.Conflicts(tt.A),
+					"%s !~ %s", tt.B, tt.A,
 				)
 			}
 		})


### PR DESCRIPTION
1. `a,b=b,a` would leave `b==c`, always returning false
2. Decimal256 should not conflict with Decimal(76, 38)
3. propagate conflicts to inner types for Nullable/Array/LowCardinality

## Checklist
- [x] Unit and integration tests covering the common scenarios were added