### PR TITLE
fix(proto): properly handle `Enum8` and `Enum8(...)` in conflicts checker

### DIFF
--- a/proto/column.go
+++ b/proto/column.go
@@ -127,9 +127,15 @@ func (c ColumnType) Conflicts(b ColumnType) bool {
 	if cBase == ColumnTypeDecimal || bBase == ColumnTypeDecimal {
 		return c.decimalDowncast() != b.decimalDowncast()
 	}
+
 	if cBase != bBase {
 		return true
 	}
+	switch cBase {
+	case ColumnTypeEnum8, ColumnTypeEnum16:
+		return false
+	}
+
 	if c.normalizeCommas() == b.normalizeCommas() {
 		return false
 	}

--- a/proto/column_test.go
+++ b/proto/column_test.go
@@ -60,6 +60,8 @@ func TestColumnType_Elem(t *testing.T) {
 				{A: "Map(String,String)", B: "Map(String, String)"},
 				{A: "Enum8('increment' = 1, 'gauge' = 2)", B: "Int8"},
 				{A: "Int8", B: "Enum8('increment' = 1, 'gauge' = 2)"},
+				{A: "Enum8('increment' = 1, 'gauge' = 2)", B: "Enum8"},
+				{A: "Enum8", B: "Enum8('increment' = 1, 'gauge' = 2)"},
 				{A: "Decimal256", B: "Decimal(76, 38)"},
 				{A: "Nullable(Decimal256)", B: "Nullable(Decimal(76, 38))"},
 			} {


### PR DESCRIPTION
Fixed regression caused by #435 (bisected to https://github.com/ClickHouse/ch-go/commit/ab04093adb55cfdfa960663ec03bac67162d151a)


