### PR TITLE
perf(compress.writer): allow creating a compress.writer with custom supported methods

### DIFF
--- a/compress/compress.go
+++ b/compress/compress.go
@@ -18,6 +18,7 @@ const (
 	LZ4
 	LZ4HC
 	ZSTD
+	NumMethods int = iota
 )
 
 type methodEncoding byte

--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -77,6 +77,32 @@ func TestCompress(t *testing.T) {
 	}
 }
 
+func TestCompressWithMethod(t *testing.T) {
+	data := []byte(strings.Repeat("Hello!\n", 25))
+	gold.Bytes(t, data, "data_raw")
+
+	for i := range MethodValues() {
+		m := MethodValues()[i]
+		t.Run(m.String(), func(t *testing.T) {
+			// Create a writer that only supports this method.
+			w := NewWriterWithMethods(0, m)
+			require.NoError(t, w.Compress(m, data))
+
+			// Using none should also work
+			require.NoError(t, w.Compress(None, data))
+		})
+	}
+
+	// Create a writer that only supports 2 methods.
+	t.Run("LZ4+ZSTD", func(t *testing.T) {
+		w := NewWriterWithMethods(0, LZ4, ZSTD)
+		require.NoError(t, w.Compress(None, data), "none method should always be accepted")
+		require.NoError(t, w.Compress(ZSTD, data))
+		require.NoError(t, w.Compress(LZ4, data))
+		require.Errorf(t, w.Compress(LZ4HC, data), "writer was not configured to accept method: LZ4HC")
+	})
+}
+
 func BenchmarkWriter_Compress(b *testing.B) {
 	// Highly compressible data.
 	data := bytes.Repeat([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, 1800)

--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -90,6 +90,13 @@ func TestCompressWithMethod(t *testing.T) {
 
 			// Using none should also work
 			require.NoError(t, w.Compress(None, data))
+
+			// Using a different method should fail.
+			nextMethod := Method((int(m) + 1) % NumMethods)
+			if nextMethod == None {
+				nextMethod = LZ4
+			}
+			require.Errorf(t, w.Compress(nextMethod, data), "writer was not configured to accept method: %s", nextMethod.String())
 		})
 	}
 

--- a/compress/writer.go
+++ b/compress/writer.go
@@ -19,13 +19,18 @@ const (
 type Writer struct {
 	Data []byte
 
-	lz4   *lz4.Compressor
-	lz4hc *lz4.CompressorHC
-	zstd  *zstd.Encoder
+	methods map[Method]bool // methods supported by this writer
+	lz4     *lz4.Compressor
+	lz4hc   *lz4.CompressorHC
+	zstd    *zstd.Encoder
 }
 
 // Compress buf into Data.
 func (w *Writer) Compress(m Method, buf []byte) error {
+	if !w.methods[m] {
+		return errors.Errorf("writer was not configured to accept method: %v", m)
+	}
+
 	maxSize := lz4.CompressBlockBound(len(buf))
 	w.Data = append(w.Data[:0], make([]byte, maxSize+headerSize)...)
 	_ = w.Data[:headerSize]
@@ -64,31 +69,60 @@ func (w *Writer) Compress(m Method, buf []byte) error {
 	return nil
 }
 
-func NewWriterWithLevel(l Level) *Writer {
-	w, err := zstd.NewWriter(nil,
-		zstd.WithEncoderLevel(zstd.SpeedDefault),
-		zstd.WithEncoderConcurrency(1),
-		zstd.WithLowerEncoderMem(true),
-	)
-	if err != nil {
-		panic(err)
+// NewWriterWithMethods creates a new Writer with the specified compression level that supports only the specified methods.
+func NewWriterWithMethods(l Level, m ...Method) *Writer {
+	methods := map[Method]bool{
+		None: true, // None is always supported
+	}
+	for _, method := range m {
+		methods[method] = true
 	}
 
-	// handle level for LZ4HC
-	levelLZ4HC := l
-	if levelLZ4HC == 0 {
-		levelLZ4HC = CompressionLevelLZ4HCDefault
-	} else {
-		levelLZ4HC = Level(math.Min(float64(levelLZ4HC), float64(CompressionLevelLZ4HCMax)))
+	var err error
+	var zstdWriter *zstd.Encoder
+	var lz4Writer *lz4.Compressor
+	var lz4hcWriter *lz4.CompressorHC
+
+	if methods[ZSTD] {
+		zstdWriter, err = zstd.NewWriter(nil,
+			zstd.WithEncoderLevel(zstd.SpeedDefault),
+			zstd.WithEncoderConcurrency(1),
+			zstd.WithLowerEncoderMem(true),
+		)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	if methods[LZ4] {
+		lz4Writer = &lz4.Compressor{}
+	}
+
+	if methods[LZ4HC] {
+		// handle level for LZ4HC
+		levelLZ4HC := l
+		if levelLZ4HC == 0 {
+			levelLZ4HC = CompressionLevelLZ4HCDefault
+		} else {
+			levelLZ4HC = Level(math.Min(float64(levelLZ4HC), float64(CompressionLevelLZ4HCMax)))
+		}
+		lz4hcWriter = &lz4.CompressorHC{Level: lz4.CompressionLevel(1 << (8 + levelLZ4HC))}
 	}
 
 	return &Writer{
-		lz4:   &lz4.Compressor{},
-		lz4hc: &lz4.CompressorHC{Level: lz4.CompressionLevel(1 << (8 + levelLZ4HC))},
-		zstd:  w,
+		methods: methods,
+		lz4:     lz4Writer,
+		lz4hc:   lz4hcWriter,
+		zstd:    zstdWriter,
 	}
 }
 
+// NewWriterWithLevel creates a new Writer with the specified compression level that supports all methods.
+func NewWriterWithLevel(l Level) *Writer {
+	return NewWriterWithMethods(l, MethodValues()...)
+}
+
+// NewWriter creates a new Writer with compression level 0 that supports all methods.
 func NewWriter() *Writer {
 	return NewWriterWithLevel(0)
 }

--- a/compress/writer.go
+++ b/compress/writer.go
@@ -108,7 +108,7 @@ func NewWriterWithMethods(l Level, m ...Method) *Writer {
 		case None:
 			// Nothing to initialize.
 		default:
-			panic(fmt.Sprintf("unsupported compression method: %v", method.String()))
+			panic(fmt.Sprintf("unsupported compression method: %s", method.String()))
 		}
 	}
 


### PR DESCRIPTION
## Summary

Currently, the compress.Writer by default allocates 3 writers: zstd, lz4, and lz4hc. All of these allocate memory by default, and many times compressors are only created to be used for just one method, like in clickhouse-go driver https://github.com/ClickHouse/clickhouse-go/blob/main/conn.go#L76-L84

In particular, this line:
https://github.com/ClickHouse/ch-go/blob/f99ba048f6bf40cc2151576ca7a3ae3686303a2d/compress/writer.go#L87


allocates ~1MB, as internally it has 2 int hashtables with 65k size each:
https://github.com/pierrec/lz4/blob/1a4bbaef2f12f93c70060b52121e992756077a1f/internal/lz4block/block.go#L303-L308


Memory usage example using clickhouse-go with no compression configured:
<img width="543" alt="image" src="https://github.com/user-attachments/assets/a08b95b3-cc9d-4f80-ae45-313869b292cd" />


## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added

