### PR TITLE
perf(compressor): reduce memory by using new compression code

### DIFF
--- a/client.go
+++ b/client.go
@@ -51,9 +51,8 @@ type Client struct {
 
 	// compressor performs block compression,
 	// see encodeBlock.
-	compressor        *compress.Writer
-	compression       proto.Compression
-	compressionMethod compress.Method
+	compressor  *compress.Writer
+	compression proto.Compression
 
 	settings []Setting
 }
@@ -491,7 +490,6 @@ func Connect(ctx context.Context, conn net.Conn, opt Options) (*Client, error) {
 	}
 
 	var (
-		compressor        = compress.NewWriterWithLevel(compress.Level(opt.CompressionLevel))
 		compression       proto.Compression
 		compressionMethod compress.Method
 	)
@@ -525,9 +523,8 @@ func Connect(ctx context.Context, conn net.Conn, opt Options) (*Client, error) {
 
 		readTimeout: opt.ReadTimeout,
 
-		compression:       compression,
-		compressionMethod: compressionMethod,
-		compressor:        compressor,
+		compression: compression,
+		compressor:  compress.NewWriter(compress.Level(opt.CompressionLevel), compressionMethod),
 
 		version:         ver,
 		protocolVersion: opt.ProtocolVersion,

--- a/compress/fuzz_test.go
+++ b/compress/fuzz_test.go
@@ -15,8 +15,8 @@ func FuzzWriter_Compress(f *testing.F) {
 	f.Add([]byte{})
 	f.Add([]byte{1, 2, 3, 4, 5})
 	f.Fuzz(func(t *testing.T, data []byte) {
-		w := NewWriter()
-		require.NoError(t, w.Compress(LZ4, data))
+		w := NewWriter(LevelZero, LZ4)
+		require.NoError(t, w.Compress(data))
 
 		r := NewReader(bytes.NewReader(w.Data))
 		out := make([]byte, len(data))
@@ -32,8 +32,8 @@ func FuzzReader_Read(f *testing.F) {
 		[]byte("Hello, world!"),
 		{1, 2, 3, 4, 5},
 	} {
-		w := NewWriter()
-		require.NoError(f, w.Compress(LZ4, data))
+		w := NewWriter(LevelZero, LZ4)
+		require.NoError(f, w.Compress(data))
 		f.Add(w.Data)
 	}
 

--- a/query.go
+++ b/query.go
@@ -315,7 +315,7 @@ func (c *Client) encodeBlock(ctx context.Context, tableName string, input []prot
 			// See "Compressible" method of server or client code for reference.
 			if c.compression == proto.CompressionEnabled {
 				data := buf.Buf[start:]
-				if err := c.compressor.Compress(c.compressionMethod, data); err != nil {
+				if err := c.compressor.Compress(data); err != nil {
 					rerr = errors.Wrap(err, "compress")
 					return
 				}

--- a/server.go
+++ b/server.go
@@ -253,7 +253,7 @@ func (s *Server) handle(conn net.Conn) error {
 			Revision: s.ver,
 		},
 		tz:         time.UTC,
-		compressor: compress.NewWriter(),
+		compressor: compress.NewWriter(compress.LevelZero, compress.None),
 	}
 	return sConn.Handle()
 }


### PR DESCRIPTION
## Summary
#1039 included some code to reduce memory usage when initializing the compressor. After further review of ch-go and clickhouse-go, it seems only _ONE_ compression method is ever used per connection. With this in mind I have refactored and simplified the code.

The most important line of this PR is to actually _USE_ the optimization from #1039:
```go
compressor:  compress.NewWriter(compress.Level(opt.CompressionLevel), compressionMethod),
```

but in addition to this I have updated some functions and constants to reflect the actual usage patterns for compression.
`*Writer.Compress()` no longer takes a `Method` since this is known during initialization and does not change.

I don't believe this is a breaking change since these packages/constants are only used internally. The compression code is abstracted by the `opt.Compression` and `opt.CompressionLevel` options.

I have also re-run the benchmarks and this code is negligibly faster by ~100ns.

Let me know if I'm wrong about the usage of any of this code. Thanks!

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
