### PR TITLE
fix(compressor): fixing an overflow that could potentially smuggle query in from data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Editors
+.idea/

--- a/compress/writer.go
+++ b/compress/writer.go
@@ -58,9 +58,8 @@ func (w *Writer) Compress(m Method, buf []byte) error {
 		n = copy(w.Data[headerSize:], buf)
 	}
 
-	if n+headerSize > cap(w.Data) {
-		return errors.New("compressed data exceeds allocated buffer capacity")
-	} else if uint64(n)+uint64(compressHeaderSize) > math.MaxUint32 {
+	// security: https://github.com/ClickHouse/ch-go/pull/1041
+	if uint64(n)+uint64(compressHeaderSize) > math.MaxUint32 {
 		return errors.New("compressed size overflows uint32")
 	}
 


### PR DESCRIPTION
## Summary

Related - https://media.defcon.org/DEF%20CON%2032/DEF%20CON%2032%20presentations/DEF%20CON%2032%20-%20Paul%20Gerste%20-%20SQL%20Injection%20Isn%27t%20Dead%20Smuggling%20Queries%20at%20the%20Protocol%20Level.pdf

It is possible to smuggle query packet into the connection when a large amount of attacker controlled data can end up in the external data of query. If Compression: CompressionNone and this overflow occurs, the remainder of the external data is processed as native protocol bytes.
