### PR TITLE
feat(time): Replace `time.Time` with `time.Duration` for Go type

### DIFF
--- a/proto/datetime64.go
+++ b/proto/datetime64.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-// Precision of DateTime64.
+// Precision of DateTime64 or Time64.
 //
 // Tick size (precision): 10^(-precision) seconds.
 // Valid range: [0:9].

--- a/proto/datetime64.go
+++ b/proto/datetime64.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-// Precision of DateTime64 or Time64.
+// Precision of DateTime64 and Time64.
 //
 // Tick size (precision): 10^(-precision) seconds.
 // Valid range: [0:9].

--- a/proto/time.go
+++ b/proto/time.go
@@ -13,6 +13,7 @@ type Time32 int32
 // Time64 represents duration up until nanoseconds.
 type Time64 int64
 
+// String implements formatting Time32 to string of form Hour:Minutes:Seconds.
 func (t Time32) String() string {
 	d := time.Duration(t) * time.Second
 
@@ -22,6 +23,7 @@ func (t Time32) String() string {
 	return fmt.Sprintf("%02d:%02d:%02d", hours, minutes, secs)
 }
 
+// String implements formatting Time64 to string of form Hour:Minutes:Seconds.NanoSeconds.
 func (t Time64) String() string {
 	d := time.Duration(t)
 
@@ -35,6 +37,7 @@ func (t Time64) String() string {
 	return fmt.Sprintf("%02d:%02d:%02d.%09d", hours, minutes, secs, nanos)
 }
 
+// ParseTime32 parses string of form "12:34:56" to valid Time32 type.
 func ParseTime32(s string) (Time32, error) {
 	parts := strings.Split(s, ":")
 	if len(parts) != 3 {
@@ -60,8 +63,8 @@ func ParseTime32(s string) (Time32, error) {
 	return Time32(totalSeconds), nil
 }
 
+// ParseTime64 parses string of form "12:34:56.789" to valid Time64 type.
 func ParseTime64(s string) (Time64, error) {
-	// Parse time string like "12:34:56.789"
 	timePart, fractionalStr, ok := strings.Cut(s, ".")
 	if !ok {
 		fractionalStr = ""
@@ -110,35 +113,36 @@ func ParseTime64(s string) (Time64, error) {
 	return Time64(totalSeconds*1e9 + fractional), nil
 }
 
+// IntoTime32 converts time.Druation into Time32 up to seconds precision.
 func IntoTime32(t time.Duration) Time32 {
 	return Time32(int(t.Seconds()))
 }
 
-// IntoTime64 converts time.Time to Time64 with default precision (9 - nanoseconds)
+// IntoTime64 converts time.Duration to Time64 up to nanoseconds precision
 func IntoTime64(t time.Duration) Time64 {
 	return IntoTime64WithPrecision(t, PrecisionMax)
 }
 
-// IntoTime64WithPrecision converts time.Time to Time64 with specified precision
-// Time64 stores time as a decimal with configurable scale, similar to DateTime64
+// IntoTime64WithPrecision converts time.Duration to Time64 with specified precision
 func IntoTime64WithPrecision(d time.Duration, precision Precision) Time64 {
 	res := truncateDuration(d, precision)
 	return Time64(res)
 }
 
+// Duration converts Time32 into time.Duration up to seconds precision
 func (t Time32) Duration() time.Duration {
 	seconds := int32(t)
 	return time.Second * time.Duration(seconds)
 }
 
-// ToTime converts Time64 to time.Time with default precision (9 - nanoseconds)
+// Duration converts Time64 into time.Duration up to nanoseconds precision
 func (t Time64) Duration() time.Duration {
-	return t.ToTimeWithPrecision(9)
+	return t.ToDurationWithPrecision(PrecisionMax)
 }
 
-// ToTimeWithPrecision converts Time64 to time.Time with specified precision
-// Time64 stores time as a decimal with configurable scale, similar to DateTime64
-func (t Time64) ToTimeWithPrecision(precision Precision) time.Duration {
+// ToDurationWithPrecision converts Time64 to time.Duration with specified precision
+// up until PrecisionMax (nanoseconds)
+func (t Time64) ToDurationWithPrecision(precision Precision) time.Duration {
 	d := time.Duration(t)
 	return truncateDuration(d, precision)
 }

--- a/proto/time_test.go
+++ b/proto/time_test.go
@@ -130,90 +130,90 @@ func TestParseTime64(t *testing.T) {
 	}
 }
 
-func TestFromTime32(t *testing.T) {
+func TestIntoTime32(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    time.Time
+		input    time.Duration
 		expected Time32
 	}{
-		{"zero time", time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC), Time32(0)},
-		{"noon", time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC), Time32(12 * 3600)},
-		{"complex time", time.Date(1970, 1, 1, 13, 45, 30, 0, time.UTC), Time32(13*3600 + 45*60 + 30)},
-		{"max time", time.Date(1970, 1, 1, 23, 59, 59, 0, time.UTC), Time32(23*3600 + 59*60 + 59)},
-		{"with nanoseconds", time.Date(1970, 1, 1, 12, 0, 0, 123456789, time.UTC), Time32(12 * 3600)},
-		{"different date", time.Date(2023, 6, 15, 14, 30, 45, 0, time.UTC), Time32(14*3600 + 30*60 + 45)},
+		{"zero time", time.Duration(0), Time32(0)},
+		{"12h", 12 * time.Hour, Time32(12 * 3600)},
+		{"13h45m30s", 13*time.Hour + 45*time.Minute + 30*time.Second, Time32(13*3600 + 45*60 + 30)},
+		{"23h59m59s", 23*time.Hour + 59*time.Minute + 59*time.Second, Time32(23*3600 + 59*60 + 59)},
+		{"time32 should ignore nanoseconds", 12*time.Hour + 123456789*time.Nanosecond, Time32(12 * 3600)},
+		{"14h30m45s", 14*time.Hour + 30*time.Minute + 45*time.Second, Time32(14*3600 + 30*60 + 45)},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := FromTime32(tt.input); got != tt.expected {
+			if got := IntoTime32(tt.input); got != tt.expected {
 				t.Errorf("FromTime32() = %v, want %v", got, tt.expected)
 			}
 		})
 	}
 }
 
-func TestFromTime64(t *testing.T) {
+func TestIntoTime64(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    time.Time
+		input    time.Duration
 		expected Time64
 	}{
-		{"zero time", time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC), Time64(0)},
-		{"noon", time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC), Time64(12 * 3600 * 1e9)},
-		{"complex time", time.Date(1970, 1, 1, 13, 45, 30, 0, time.UTC), Time64((13*3600 + 45*60 + 30) * 1e9)},
-		{"max time", time.Date(1970, 1, 1, 23, 59, 59, 0, time.UTC), Time64((23*3600 + 59*60 + 59) * 1e9)},
-		{"with nanoseconds", time.Date(1970, 1, 1, 12, 0, 0, 123456789, time.UTC), Time64(12*3600*1e9 + 123456789)},
-		{"different date", time.Date(2023, 6, 15, 14, 30, 45, 123456789, time.UTC), Time64((14*3600+30*60+45)*1e9 + 123456789)},
+		{"zero time", time.Duration(0), Time64(0)},
+		{"12h", 12 * time.Hour, Time64(12 * 3600 * 1e9)},
+		{"13h45m30s", 13*time.Hour + 45*time.Minute + 30*time.Second, Time64((13*3600 + 45*60 + 30) * 1e9)},
+		{"23h59m59s", 23*time.Hour + 59*time.Minute + 59*time.Second, Time64((23*3600 + 59*60 + 59) * 1e9)},
+		{"time64 should not ignore nanoseconds", 12*time.Hour + 123456789*time.Nanosecond, Time64(12*3600*1e9 + 123456789)},
+		{"14h30m45s123456789ns", 14*time.Hour + 30*time.Minute + 45*time.Second + 123456789*time.Nanosecond, Time64((14*3600+30*60+45)*1e9 + 123456789)},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := FromTime64(tt.input); got != tt.expected {
+			if got := IntoTime64(tt.input); got != tt.expected {
 				t.Errorf("FromTime64() = %v, want %v", got, tt.expected)
 			}
 		})
 	}
 }
 
-func TestTime32_ToTime32(t *testing.T) {
+func TestTime32_Duration(t *testing.T) {
 	tests := []struct {
 		name     string
 		time     Time32
-		expected time.Time
+		expected time.Duration
 	}{
-		{"zero", Time32(0), time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)},
-		{"noon", Time32(12 * 3600), time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC)},
-		{"complex time", Time32(13*3600 + 45*60 + 30), time.Date(1970, 1, 1, 13, 45, 30, 0, time.UTC)},
-		{"max time", Time32(23*3600 + 59*60 + 59), time.Date(1970, 1, 1, 23, 59, 59, 0, time.UTC)},
+		{"zero", Time32(0), time.Duration(0)},
+		{"12h", Time32(12 * 3600), 12 * time.Hour},
+		{"13h45m30s", Time32(13*3600 + 45*60 + 30), 13*time.Hour + 45*time.Minute + 30*time.Second},
+		{"23h59m59s", Time32(23*3600 + 59*60 + 59), 23*time.Hour + 59*time.Minute + 59*time.Second},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.time.ToTime32(); !got.Equal(tt.expected) {
-				t.Errorf("Time32.ToTime32() = %v, want %v", got, tt.expected)
+			if got := tt.time.Duration(); got != tt.expected {
+				t.Errorf("Time32.Duration() = %v, want %v", got, tt.expected)
 			}
 		})
 	}
 }
 
-func TestTime64_ToTime(t *testing.T) {
+func TestTime64_Duration(t *testing.T) {
 	tests := []struct {
 		name     string
 		time     Time64
-		expected time.Time
+		expected time.Duration
 	}{
-		{"zero", Time64(0), time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)},
-		{"noon", Time64(12 * 3600 * 1e9), time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC)},
-		{"complex time", Time64((13*3600 + 45*60 + 30) * 1e9), time.Date(1970, 1, 1, 13, 45, 30, 0, time.UTC)},
-		{"max time", Time64((23*3600 + 59*60 + 59) * 1e9), time.Date(1970, 1, 1, 23, 59, 59, 0, time.UTC)},
-		{"with nanoseconds", Time64(12*3600*1e9 + 123456789), time.Date(1970, 1, 1, 12, 0, 0, 123456789, time.UTC)},
+		{"zero", Time64(0), time.Duration(0)},
+		{"12h", Time64(12 * 3600 * 1e9), 12 * time.Hour},
+		{"13h45m30s", Time64((13*3600 + 45*60 + 30) * 1e9), 13*time.Hour + 45*time.Minute + 30*time.Second},
+		{"23h59m59s", Time64((23*3600 + 59*60 + 59) * 1e9), 23*time.Hour + 59*time.Minute + 59*time.Second},
+		{"12h123456789ns", Time64(12*3600*1e9 + 123456789), 12*time.Hour + 123456789*time.Nanosecond},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.time.ToTime(); !got.Equal(tt.expected) {
-				t.Errorf("Time64.ToTime() = %v, want %v", got, tt.expected)
+			if got := tt.time.Duration(); got != tt.expected {
+				t.Errorf("Time64.Duration() = %v, want %v", got, tt.expected)
 			}
 		})
 	}
@@ -295,10 +295,10 @@ func TestTime32_TimeConversion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Convert to time.Time
-			t1 := tt.time.ToTime32()
+			t1 := tt.time.Duration()
 
 			// Convert back
-			t2 := FromTime32(t1)
+			t2 := IntoTime32(t1)
 
 			if t2 != tt.time {
 				t.Errorf("Time conversion failed: original = %v, converted back = %v", tt.time, t2)
@@ -322,10 +322,10 @@ func TestTime64_TimeConversion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Convert to time.Time
-			t1 := tt.time.ToTime()
+			t1 := tt.time.Duration()
 
 			// Convert back
-			t2 := FromTime64(t1)
+			t2 := IntoTime64(t1)
 
 			if t2 != tt.time {
 				t.Errorf("Time conversion failed: original = %v, converted back = %v", tt.time, t2)
@@ -361,15 +361,15 @@ func BenchmarkParseTime64(b *testing.B) {
 }
 
 func BenchmarkFromTime32(b *testing.B) {
-	t := time.Date(1970, 1, 1, 12, 34, 56, 0, time.UTC)
+	t := 12*time.Hour + 34*time.Minute + 56*time.Second
 	for i := 0; i < b.N; i++ {
-		_ = FromTime32(t)
+		_ = IntoTime32(t)
 	}
 }
 
 func BenchmarkFromTime64(b *testing.B) {
-	t := time.Date(1970, 1, 1, 12, 34, 56, 123456789, time.UTC)
+	t := 12*time.Hour + 34*time.Minute + 56*time.Second + 123456789*time.Nanosecond
 	for i := 0; i < b.N; i++ {
-		_ = FromTime64(t)
+		_ = IntoTime64(t)
 	}
 }


### PR DESCRIPTION


## Summary
<!-- A short description of the changes with a link to an open issue. -->
Currently time and time64 types are treated as Go's `time.Time` for inserts and scan.

This causes lots of complexity and bad UX for users.
1. We have to deal with Day, Month and Year eventhough that is not part of original CH time and time64 types
2. Handling timezone. Which is also not part of CH types.

Having coming up with "sane" zero values is super cumbersome. Plus it's going to be bad UX for developers if want to do some arithmetic on those types.

This PR converts that to more sane `time.Duration` type. This type fits naturally to CH time and time64 types.
[
Also see this comment](https://github.com/ClickHouse/clickhouse-go/pull/1669/files#r2398218310)

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
