### PR TITLE
fix: precision scaling behaviour with time64 conversions

### DIFF
--- a/proto/time.go
+++ b/proto/time.go
@@ -145,6 +145,8 @@ func (t Time64) Duration() time.Duration {
 // ToDurationWithPrecision converts Time64 to time.Duration with specified precision
 // up until PrecisionMax (nanoseconds)
 func (t Time64) ToDurationWithPrecision(precision Precision) time.Duration {
+	// `t` is stored with precision `precision`. Scale it to nanoseconds before converting it into
+	// time.Duration. Because time.Duration is always nanoseconds.
 	res := time.Duration(int64(t) * precision.Scale())
 	return truncateDuration(res, precision)
 }


### PR DESCRIPTION
## Summary
fix: precision scaling behaviour with time64 conversions

Related to bug reported in clickhouse-go repo
https://github.com/ClickHouse/clickhouse-go/issues/1757

Basically we have scale the underlying Time64 precision (`ms`, `us` or `ns`) to the Column type. Otherwise if we store all the values as nano seconds and sending `123456000` nanoseconds to column of type `Time64(6)` will treat it as micro seconds.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
