### PR TITLE
More than one external table in ch.Query

### DIFF
--- a/query.go
+++ b/query.go
@@ -120,6 +120,16 @@ func (c *Client) sendQuery(ctx context.Context, q Query) error {
 			return errors.Wrap(err, "external data")
 		}
 	}
+
+	for _, t := range q.ExternalTables {
+		if t.Name == "" {
+			return errors.New("external table needs a name")
+		}
+		if err := c.encodeBlock(ctx, t.Name, t.Data); err != nil {
+			return errors.Wrapf(err, "external table %q", t.Name)
+		}
+	}
+
 	// End of external data.
 	if err := c.encodeBlankBlock(ctx); err != nil {
 		return errors.Wrap(err, "external data end")
@@ -196,8 +206,19 @@ type Query struct {
 	// ExternalTable name. Defaults to _data.
 	ExternalTable string
 
+	// ExternalTables is additional external tables sent to server.
+	// If ExternalData is not empty, it's sent along with this tables.
+	ExternalTables []ExternalTable
+
 	// Logger for query, optional, defaults to client logger with `query_id` field.
 	Logger *zap.Logger
+}
+
+// ExternalTable is additional data that can be sent along with query.
+// External tables can be referred by their name just like any temporary table.
+type ExternalTable struct {
+	Name string
+	Data proto.Input
 }
 
 // CorruptedDataErr means that provided hash mismatch with calculated.

--- a/query_test.go
+++ b/query_test.go
@@ -1239,6 +1239,43 @@ func TestClient_ExternalData(t *testing.T) {
 		require.NoError(t, Conn(t).Do(ctx, selectStr))
 		require.Equal(t, 3, data.Rows())
 	})
+	t.Run("More", func(t *testing.T) {
+		t.Parallel()
+		var data proto.ColInt64
+		selectStr := Query{
+			Body: "SELECT * FROM external0",
+			ExternalTables: []ExternalTable{
+				{Name: "external0", Data: proto.Input{
+					{Name: "v", Data: proto.ColInt64{1, 2, 3}},
+				}},
+			},
+			Result: proto.Results{
+				{Name: "v", Data: &data},
+			},
+		}
+		require.NoError(t, Conn(t).Do(ctx, selectStr))
+		require.Equal(t, 3, data.Rows())
+	})
+	t.Run("DefaultAndMore", func(t *testing.T) {
+		t.Parallel()
+		var data proto.ColInt64
+		selectStr := Query{
+			Body: "SELECT * FROM _data INNER JOIN external0 USING v",
+			ExternalData: []proto.InputColumn{
+				{Name: "v", Data: proto.ColInt64{1, 2, 3}},
+			},
+			ExternalTables: []ExternalTable{
+				{Name: "external0", Data: proto.Input{
+					{Name: "v", Data: proto.ColInt64{1, 2, 3}},
+				}},
+			},
+			Result: proto.Results{
+				{Name: "v", Data: &data},
+			},
+		}
+		require.NoError(t, Conn(t).Do(ctx, selectStr))
+		require.Equal(t, 3, data.Rows())
+	})
 }
 
 func TestClient_ServerProfile(t *testing.T) {


### PR DESCRIPTION
## Summary
More than one external table can be added to a query.
https://github.com/ClickHouse/ch-go/issues/1158

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
