### PR TITLE
fix(qbit): match ClickHouse byte order for dimension > 8

### DIFF
--- a/proto/col_qbit.go
+++ b/proto/col_qbit.go
@@ -16,8 +16,12 @@ import (
 //
 // Internally, QBit is represented as a Tuple of FixedString columns where:
 //   - Number of columns = bit width of element type (16/32/64)
-//   - Each FixedString length = dimension (stores one bit from each element)
-//   - Column i stores the i-th bit from all elements of all vectors
+//   - Each FixedString is ceil(dimension/8) bytes, one bit per element
+//   - Column i holds bit i (MSB first) of every element
+//
+// Within a plane CH reverses byte groups: element e occupies byte
+// bytesPerRow-1-e/8, bit e%8. So for dimension>8 element group 0 lands in the
+// last byte. See ClickHouse SerializationQBit::transposeBits.
 type ColQBit struct {
 	// elementType can be BFloat16, Float32, or Float64
 	elementType ColumnType
@@ -147,7 +151,8 @@ func (c *ColQBit) Row(i int) []float32 {
 
 	// Reconstruct each element from its bits across all bit planes
 	for elemIdx := range c.dimension {
-		byteIdx := elemIdx / 8
+		// CH byte-group reversal within plane
+		byteIdx := c.bytesPerRow - 1 - elemIdx/8
 		bitIdx := uint(elemIdx % 8)
 
 		var bits uint64
@@ -204,7 +209,8 @@ func (c *ColQBit) Append(vector []float32) error {
 		bitMask := uint64(1) << uint(c.bitWidth-1-planeIdx)
 		for elemIdx := range c.dimension {
 			if (bits[elemIdx] & bitMask) != 0 {
-				byteIdx := elemIdx / 8
+				// CH byte-group reversal within plane
+				byteIdx := c.bytesPerRow - 1 - elemIdx/8
 				bitIdx := uint(elemIdx % 8)
 				c.bitPlanes[planeIdx][startLen+byteIdx] |= 1 << bitIdx
 			}

--- a/proto/col_qbit_test.go
+++ b/proto/col_qbit_test.go
@@ -281,6 +281,30 @@ func TestColQBit_EncodeDecodeRoundtrip_BFloat16(t *testing.T) {
 	}
 }
 
+func TestColQBit_CHByteOrder(t *testing.T) {
+	// CH stores element group g in byte bytesPerRow-1-g, so element 0 lands in last
+	// byte and element 8 in the first. Plane 0 is MSB = sign bit for Float32.
+	// Self-consistent Append/Row round-trips can't catch a byte-order regression.
+	col, err := NewColQBit(ColumnTypeFloat32, 9)
+	require.NoError(t, err)
+
+	v := make([]float32, 9)
+	for i := range v {
+		v[i] = 1.0
+	}
+	v[0] = -1.0
+	require.NoError(t, col.Append(v))
+	assert.Equal(t, []byte{0x00, 0x01}, col.bitPlanes[0], "element 0 → last byte")
+
+	col.Reset()
+	for i := range v {
+		v[i] = 1.0
+	}
+	v[8] = -1.0
+	require.NoError(t, col.Append(v))
+	assert.Equal(t, []byte{0x01, 0x00}, col.bitPlanes[0], "element 8 → first byte")
+}
+
 func TestColQBit_Reset(t *testing.T) {
 	col, err := NewColQBit(ColumnTypeFloat32, 4)
 	require.NoError(t, err)

--- a/query_test.go
+++ b/query_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"math/rand"
 	"net/netip"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -1570,4 +1572,52 @@ func TestClient_querySettings(t *testing.T) {
 		{Key: "custom_query", Value: "q", Custom: true},
 		{Key: "custom_query_important", Value: "qi", Important: true, Custom: true},
 	}, got)
+}
+
+// TestQBitWireParity verifies ch-go's QBit bit-plane transpose is byte-identical
+// to ClickHouse's, including the byte-group reversal within multi-byte planes
+// (dimension > 8).
+func TestQBitWireParity(t *testing.T) {
+	conn := Conn(t)
+
+	// QBit is Beta (default-on) since 26.1; absent before 25.10.
+	if v := conn.ServerInfo(); v.Major < 26 || (v.Major == 26 && v.Minor < 1) {
+		t.Skipf("QBit unsupported on %d.%d", v.Major, v.Minor)
+	}
+
+	// Span single-byte (<=8) and multi-byte planes with various trailing remainders.
+	for _, n := range []int{8, 9, 16, 17, 100, 257} {
+		t.Run(fmt.Sprintf("Float32_dim%d", n), func(t *testing.T) {
+			vec := make([]float32, n)
+			parts := make([]string, len(vec))
+			for i := range vec {
+				vec[i] = float32(i-n/2) + 0.5
+				parts[i] = strconv.FormatFloat(float64(vec[i]), 'g', -1, 32)
+			}
+			floatArrayLiteral := "[" + strings.Join(parts, ",") + "]"
+
+			// ch-go encodes the vector.
+			goCol, err := proto.NewColQBit(proto.ColumnTypeFloat32, n)
+			require.NoError(t, err)
+			require.NoError(t, goCol.Append(vec))
+
+			// ClickHouse encodes the same vector; received as raw planes over native.
+			chCol, err := proto.NewColQBit(proto.ColumnTypeFloat32, n)
+			require.NoError(t, err)
+			require.NoError(t, conn.Do(t.Context(), Query{
+				Body:   fmt.Sprintf("SELECT CAST(%s AS QBit(Float32, %d)) AS v", floatArrayLiteral, n),
+				Result: proto.Results{{Name: "v", Data: chCol}},
+			}))
+			require.Equal(t, 1, chCol.Rows())
+
+			// Bit-planes must be byte-identical on the wire.
+			var goBuf, chBuf proto.Buffer
+			goCol.EncodeColumn(&goBuf)
+			chCol.EncodeColumn(&chBuf)
+			require.Equal(t, chBuf.Buf, goBuf.Buf, "ch-go encoding differs from ClickHouse")
+
+			// ch-go decodes ClickHouse-produced planes back to the original vector.
+			assert.Equal(t, vec, chCol.Row(0))
+		})
+	}
 }


### PR DESCRIPTION
## Summary
Row/Append placed element groups in natural byte order, CH reverses them within each FixedString plane

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added