### PR TITLE
fix(ci): regressions due to ClickHouse changes

### DIFF
--- a/cht/cht_test.go
+++ b/cht/cht_test.go
@@ -52,7 +52,6 @@ func TestConnect(t *testing.T) {
 	ctx := context.Background()
 	server := cht.New(t,
 		cht.WithLog(ztest.NewLogger(t)),
-		cht.WithMaxServerMemoryUsage(1024*1024*256),
 	)
 	t.Parallel()
 

--- a/cht/local_test.go
+++ b/cht/local_test.go
@@ -57,6 +57,8 @@ func TestLocalNativeDump(t *testing.T) {
 		"--file", inFile,
 		"--input-format", "Native",
 		"--output-format", "JSON",
+		// ClickHouse 25.8 flipped this default to false, pin it so 64-bit ints stay quoted for ,string parsing below
+		"--output_format_json_quote_64bit_integers", "1",
 		"--query", "SELECT * FROM table",
 	)
 	out := new(bytes.Buffer)


### PR DESCRIPTION
TestLocalNativeDump (failed on all versions ≥25.8)
ClickHouse 25.8 flipped output_format_json_quote_64bit_integers default to false

TestConnect (failed on v26.x only)
v26.x's memory tracker now counts total process RSS, which already exceeds cap at handshake