### PR TITLE
Add client hostname option

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -35,6 +37,7 @@ type Client struct {
 	info     proto.ClientHello
 	server   proto.ServerHello
 	version  clientVersion
+	hostname string
 	quotaKey string
 
 	mux    sync.Mutex
@@ -447,15 +450,8 @@ func Connect(ctx context.Context, conn net.Conn, opt Options) (*Client, error) {
 func ConnectWithBuffer(ctx context.Context, conn net.Conn, opt Options, buf *proto.Buffer) (*Client, error) {
 	opt.setDefaults()
 
-	clientName := proto.Name
 	pkg := pkgVersion.Get()
-	if opt.ClientName == "" {
-		if pkg.Name != "" {
-			clientName = fmt.Sprintf("%s (%s)", clientName, pkg.Name)
-		}
-	} else {
-		clientName = fmt.Sprintf("%s %s", clientName, opt.ClientName)
-	}
+	clientName := formatClientName(opt.ClientName, pkg)
 	ver := clientVersion{
 		Name:  clientName,
 		Major: pkg.Major,
@@ -499,6 +495,7 @@ func ConnectWithBuffer(ctx context.Context, conn net.Conn, opt Options, buf *pro
 	if opt.SSHSigner != nil {
 		user = " SSH KEY AUTHENTICATION " + user
 	}
+	hostname, _ := os.Hostname()
 
 	c := &Client{
 		conn:     conn,
@@ -510,6 +507,7 @@ func ConnectWithBuffer(ctx context.Context, conn net.Conn, opt Options, buf *pro
 		tracer:   opt.tracer,
 		meter:    opt.meter,
 		quotaKey: opt.QuotaKey,
+		hostname: hostname,
 
 		readTimeout: opt.ReadTimeout,
 
@@ -537,6 +535,29 @@ func ConnectWithBuffer(ctx context.Context, conn net.Conn, opt Options, buf *pro
 	}
 
 	return c, nil
+}
+
+func formatClientName(clientName string, pkg pkgVersion.Value) string {
+	libraryProduct := formatLibraryProduct(pkg)
+	metadata := formatClientMetadata()
+	if clientName == "" {
+		if pkg.Name != "" {
+			return fmt.Sprintf("%s (%s) %s", proto.Name, pkg.Name, metadata)
+		}
+		return fmt.Sprintf("%s %s", proto.Name, metadata)
+	}
+	return fmt.Sprintf("%s %s %s", clientName, libraryProduct, metadata)
+}
+
+func formatLibraryProduct(pkg pkgVersion.Value) string {
+	if pkg.Raw != "" {
+		return proto.Name + "/" + strings.TrimPrefix(pkg.Raw, "v")
+	}
+	return fmt.Sprintf("%s/%d.%d.%d", proto.Name, pkg.Major, pkg.Minor, pkg.Patch)
+}
+
+func formatClientMetadata() string {
+	return fmt.Sprintf("(lv:go/%s; os:%s)", strings.TrimPrefix(runtime.Version(), "go"), runtime.GOOS)
 }
 
 // A Dialer dials using a context.

--- a/query.go
+++ b/query.go
@@ -102,7 +102,7 @@ func (c *Client) sendQuery(ctx context.Context, q Query) error {
 			InitialQueryID: q.QueryID,
 			InitialAddress: c.conn.LocalAddr().String(),
 			OSUser:         "",
-			ClientHostname: "",
+			ClientHostname: c.hostname,
 			ClientName:     c.version.Name,
 
 			Span:     trace.SpanContextFromContext(ctx),


### PR DESCRIPTION
## Summary

- Propagate os.Hostname() to query `ClientInfo.ClientHostname`.
- Format custom `ClientName` in clickhouse-go style: application product first, then ch-go product.
- Append Go runtime and OS metadata to `ClientName`, for example:
  `application/v1.85.2 clickhouse/ch-go/0.71.0 (lv:go/1.26.4; os:linux)`.

## Motivation

ClickHouse query logs expose both `client_hostname` and `client_name`. Applications need to use these fields for different attribution dimensions:

- `client_hostname`: pod or host identity.
- `client_name`: application/library identity and versions.

This makes it easier to filter by service/version and separately group by pod/host.

## Checklist
- [x] A human-readable description of the changes was provided to include in CHANGELOG
