### PR TITLE
fix(proto): return error for unsupported custom serialization

### DIFF
--- a/proto/column.go
+++ b/proto/column.go
@@ -320,7 +320,7 @@ func (s *ColInfoInput) DecodeResult(r *Reader, version int, b Block) error {
 				return errors.Wrapf(err, "column [%d] custom serialization", i)
 			}
 			if customSerialization {
-				return errors.Wrapf(err, "column [%d] has custom serialization (not supported)", i)
+				return errors.Errorf("column [%d] has custom serialization (not supported)", i)
 			}
 		}
 		*s = append(*s, ColInfo{

--- a/proto/column_test.go
+++ b/proto/column_test.go
@@ -35,6 +35,23 @@ func checkWriteColumn(data ColInput) func(*testing.T) {
 	}
 }
 
+func TestColInfoInput_DecodeResult(t *testing.T) {
+	t.Run("custom serialization", func(t *testing.T) {
+		var b Buffer
+		b.PutString("column")
+		b.PutString("String")
+		b.PutBool(true)
+
+		var got ColInfoInput
+		err := got.DecodeResult(
+			b.Reader(),
+			FeatureCustomSerialization.Version(),
+			Block{Columns: 1},
+		)
+		require.EqualError(t, err, "column [0] has custom serialization (not supported)")
+	})
+}
+
 func TestColumnType_Elem(t *testing.T) {
 	t.Run("Array", func(t *testing.T) {
 		v := ColumnTypeInt16.Array()


### PR DESCRIPTION
## What does this change?

Return an actual error when a result column uses custom serialization.

`ColInfoInput.DecodeResult` already checks the flag, but the error branch wrapped the previous `err` value. After a successful `Bool` read, that value is nil, so the branch returned nil and decoding continued.

Custom serialization is not supported, so decoding should stop instead of accepting the column metadata.

## Tests

- `go test ./...`