### PR TITLE
doc: clarify the server side query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,47 @@ q := ch.Query{
 }
 ```
 
+### Server-side query parameters
+
+ClickHouse server-side query parameters use typed placeholders in the form `{name:Type}`. The query and parameter values are sent separately, so values are not interpolated into the SQL text. They require ClickHouse 22.8 or later.
+
+Use `ch.Parameters` to build `Query.Parameters`:
+
+```go
+var (
+    userID  proto.ColUInt64
+    message proto.ColStr
+)
+err := conn.Do(ctx, ch.Query{
+    Body: "SELECT {user_id:UInt64}, {message:String}",
+    Parameters: ch.Parameters(map[string]any{
+        "user_id": 12345,
+        "message": `line 1\\nline 2`,
+    }),
+    Result: proto.Results{
+        {Data: &userID},
+        {Data: &message},
+    },
+})
+```
+
+#### String values and escape sequences
+
+`ch.Parameters` formats each value and encloses it in single quotes. ClickHouse first decodes that quoted value and then parses it using the placeholder's declared type. A backslash escape must therefore survive two ClickHouse parsing steps, in addition to Go's own string-literal processing.
+
+Common ClickHouse escapes include `\n` (newline), `\t` (tab), `\r` (carriage return), `\0` (null byte), and `\\` (a literal backslash). Write string parameters as follows:
+
+| Value received by ClickHouse | Go raw string literal | Go interpreted string literal |
+|---|---|---|
+| Newline and tab | `` `line 1\\nline 2\\tend` `` | `"line 1\\\\nline 2\\\\tend"` |
+| Literal `\n` and `\t` text | `` `line 1\\\\nline 2\\\\tend` `` | `"line 1\\\\\\\\nline 2\\\\\\\\tend"` |
+
+Do not use `` `line 1\nline 2` ``, `"line 1\\nline 2"`, or `"line 1\nline 2"` when the result should contain a newline. The first two forms lose their only backslash during quoted-value decoding; the last already contains an actual newline. In all three cases, the second parsing step sees an unescaped field delimiter and rejects the parameter as incompletely parsed.
+
+You can construct `[]proto.Parameter` directly, but then each `Value` must include the ClickHouse quotes and escaping that `ch.Parameters` normally adds. Prefer the helper unless you specifically need complete control over the wire representation.
+
+[Full example](./examples/query_parameters)
+
 ### Writing data
 
 See [examples/insert](./examples/insert).
@@ -261,6 +302,7 @@ colV.Reset()
 * No reflection or `interface{}`
 * Generics (go1.18) for `Array[T]`, `LowCardinaliy[T]`, `Map[K, V]`, `Nullable[T]`
 * [Reading or writing](#dumps) ClickHouse dumps in `Native` format
+* [Server-side query parameters](#server-side-query-parameters)
 * **Column**-oriented design that operates directly with **blocks** of data
   * [Dramatically more efficient](https://github.com/ClickHouse/ch-bench)
   * Up to 100x faster than row-first design around `sql`

--- a/client_test.go
+++ b/client_test.go
@@ -37,7 +37,9 @@ func ConnOpt(t testing.TB, opt Options) *Client {
 
 	t.Log("Connected", client.ServerInfo())
 	t.Cleanup(func() {
-		require.NoError(t, client.Close())
+		if !client.IsClosed() {
+			require.NoError(t, client.Close())
+		}
 	})
 
 	return client

--- a/examples/query_parameters/main.go
+++ b/examples/query_parameters/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ClickHouse/ch-go"
+	"github.com/ClickHouse/ch-go/proto"
+)
+
+func main() {
+	ctx := context.Background()
+	conn, err := ch.Dial(ctx, ch.Options{})
+	if err != nil {
+		panic(err)
+	}
+	defer conn.Close()
+
+	var (
+		userID             proto.ColUInt64
+		escapedRaw         proto.ColStr
+		escapedInterpreted proto.ColStr
+		literalBackslash   proto.ColStr
+	)
+
+	// ch.Parameters adds single quotes around each value. Backslash escapes
+	// therefore need to survive both quoted-value and parameter-value parsing.
+	err = conn.Do(ctx, ch.Query{
+		Body: `SELECT
+			{user_id:UInt64},
+			{escaped_raw:String},
+			{escaped_interpreted:String},
+			{literal_backslash:String}`,
+		Parameters: ch.Parameters(map[string]any{
+			"user_id":             12345,
+			"escaped_raw":         `line 1\\nline 2\\tend`,
+			"escaped_interpreted": "line 1\\\\nline 2\\\\tend",
+			"literal_backslash":   `line 1\\\\nline 2`,
+		}),
+		Result: proto.Results{
+			{Data: &userID},
+			{Data: &escapedRaw},
+			{Data: &escapedInterpreted},
+			{Data: &literalBackslash},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("userID=%d escapedRaw=%q escapedInterpreted=%q literalBackslash=%q\n",
+		userID.Row(0), escapedRaw.Row(0), escapedInterpreted.Row(0), literalBackslash.Row(0))
+}

--- a/examples/query_parameters/main.go
+++ b/examples/query_parameters/main.go
@@ -14,7 +14,11 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			panic(err)
+		}
+	}()
 
 	var (
 		userID             proto.ColUInt64

--- a/query_params.go
+++ b/query_params.go
@@ -7,7 +7,13 @@ import (
 	"github.com/ClickHouse/ch-go/proto"
 )
 
-// Parameters is helper for building Query.Parameters.
+// Parameters is a helper for building Query.Parameters.
+//
+// Each value is formatted with fmt and enclosed in single quotes. ClickHouse
+// decodes the quoted value before parsing it as the placeholder's declared
+// type. Consequently, backslash escape sequences need to survive two
+// ClickHouse parsing steps. For example, use `line 1\\nline 2` to receive a
+// newline, or `line 1\\\\nline 2` to receive the literal characters \ and n.
 //
 // EXPERIMENTAL.
 func Parameters(m map[string]any) []proto.Parameter {

--- a/query_params_test.go
+++ b/query_params_test.go
@@ -13,12 +13,80 @@ func TestQueryParameters(t *testing.T) {
 	conn := Conn(t)
 	SkipNoFeature(t, conn, proto.FeatureParameters)
 	ctx := context.Background()
+
+	var (
+		num                proto.ColUInt8
+		str                proto.ColStr
+		escapedRaw         proto.ColStr
+		escapedInterpreted proto.ColStr
+		literalBackslash   proto.ColStr
+	)
 	require.NoError(t, conn.Do(ctx, Query{
-		Body: "select {num:UInt8} v, {str:String} s",
+		Body: `SELECT
+			{num:UInt8},
+			{str:String},
+			{escaped_raw:String},
+			{escaped_interpreted:String},
+			{literal_backslash:String}`,
 		Parameters: Parameters(map[string]any{
-			"num": 100,
-			"str": "foo",
+			"num":                 100,
+			"str":                 "foo",
+			"escaped_raw":         `line 1\\nline 2\\tend`,
+			"escaped_interpreted": "line 1\\\\nline 2\\\\tend",
+			"literal_backslash":   `line 1\\\\nline 2`,
 		}),
-		Result: discardResult(),
+		Result: proto.Results{
+			{Data: &num},
+			{Data: &str},
+			{Data: &escapedRaw},
+			{Data: &escapedInterpreted},
+			{Data: &literalBackslash},
+		},
 	}))
+	require.Equal(t, uint8(100), num.Row(0))
+	require.Equal(t, "foo", str.Row(0))
+	require.Equal(t, "line 1\nline 2\tend", escapedRaw.Row(0))
+	require.Equal(t, "line 1\nline 2\tend", escapedInterpreted.Row(0))
+	require.Equal(t, `line 1\nline 2`, literalBackslash.Row(0))
+
+	t.Run("escaped string values", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			value string
+			want  string
+		}{
+			{"raw literal with escapes", `line 1\\nline 2\\tend`, "line 1\nline 2\tend"},
+			{"interpreted literal with escaped backslashes", "line 1\\\\nline 2\\\\tend", "line 1\nline 2\tend"},
+			{"raw literal with literal backslashes", `line 1\\\\nline 2\\\\tend`, `line 1\nline 2\tend`},
+			{"interpreted literal with literal backslashes", "line 1\\\\\\\\nline 2\\\\\\\\tend", `line 1\nline 2\tend`},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				var got proto.ColStr
+				err := conn.Do(ctx, Query{
+					Body:       "SELECT {value:String}",
+					Parameters: Parameters(map[string]any{"value": tc.value}),
+					Result:     proto.Results{{Data: &got}},
+				})
+				require.NoError(t, err)
+				require.Equal(t, tc.want, got.Row(0))
+			})
+		}
+
+		for name, value := range map[string]string{
+			"single escaped newline": `line 1\nline 2`,
+			"actual newline":         "line 1\nline 2",
+			"actual tab":             "column 1\tcolumn 2",
+		} {
+			t.Run("reject "+name, func(t *testing.T) {
+				conn := Conn(t)
+				err := conn.Do(ctx, Query{
+					Body:       "SELECT {value:String}",
+					Parameters: Parameters(map[string]any{"value": value}),
+					Result:     discardResult(),
+				})
+				require.Error(t, err, "value %q should be rejected", value)
+			})
+		}
+	})
 }


### PR DESCRIPTION


## Summary
<!-- A short description of the changes with a link to an open issue. -->
Similar to https://github.com/ClickHouse/clickhouse-go/pull/1977 but for ch-go

Changes
1. Docs update about server side query params with handling escape characters correctly
2. Examples
3. Tests to avoid any regression behaviour

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
