### PR TITLE
chore: fix linter error with deprecated api

### DIFF
--- a/internal/cmd/ch-bench-trace-id/main.go
+++ b/internal/cmd/ch-bench-trace-id/main.go
@@ -123,16 +123,18 @@ func run(ctx context.Context) error {
 					Important: true,
 				},
 			},
-			OnLog: func(ctx context.Context, l ch.Log) error {
-				switch l.Source {
-				case "MemoryTracker": // ok
-				default:
-					return nil // skip
+			OnLogs: func(ctx context.Context, ls []ch.Log) error {
+				for _, l := range ls {
+					switch l.Source {
+					case "MemoryTracker": // ok
+					default:
+						continue // skip
+					}
+					lg.Info("Log",
+						zap.String("source", l.Source),
+						zap.String("text", l.Text),
+					)
 				}
-				lg.Info("Log",
-					zap.String("source", l.Source),
-					zap.String("text", l.Text),
-				)
 				return nil
 			},
 			OnInput: func(ctx context.Context) error {

--- a/internal/cmd/ch-bench-trace-id/main.go
+++ b/internal/cmd/ch-bench-trace-id/main.go
@@ -169,16 +169,18 @@ func run(ctx context.Context) error {
 				// Skip.
 				return nil
 			},
-			OnLog: func(ctx context.Context, l ch.Log) error {
-				switch l.Source {
-				case "MemoryTracker", "executeQuery": // ok
-				default:
-					return nil // skip
+			OnLogs: func(ctx context.Context, ls []ch.Log) error {
+				for _, l := range ls {
+					switch l.Source {
+					case "MemoryTracker", "executeQuery": // ok
+					default:
+						continue // skip
+					}
+					lg.Info("Log",
+						zap.String("source", l.Source),
+						zap.String("text", l.Text),
+					)
 				}
-				lg.Info("Log",
-					zap.String("source", l.Source),
-					zap.String("text", l.Text),
-				)
 				return nil
 			},
 			Result: proto.Results{


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

Replace `onLog` -> `onLogs` to avoid linter complains

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
