### PR TITLE
fix: escape quotes and backslashes in ch.Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ err := conn.Do(ctx, ch.Query{
     Body: "SELECT {user_id:UInt64}, {message:String}",
     Parameters: ch.Parameters(map[string]any{
         "user_id": 12345,
-        "message": `line 1\\nline 2`,
+        "message": `line 1\nline 2`,
     }),
     Result: proto.Results{
         {Data: &userID},
@@ -111,18 +111,18 @@ err := conn.Do(ctx, ch.Query{
 
 #### String values and escape sequences
 
-`ch.Parameters` formats each value and encloses it in single quotes. ClickHouse first decodes that quoted value and then parses it using the placeholder's declared type. A backslash escape must therefore survive two ClickHouse parsing steps, in addition to Go's own string-literal processing.
+`ch.Parameters` formats each value as a quoted Field dump, escaping `\` and `'` so the server's `readQuoted` step restores the text you passed. ClickHouse then parses that text as Escaped-format input for the placeholder's declared type (`\n`, `\t`, `\r`, `\0`, `\\`, …).
 
-Common ClickHouse escapes include `\n` (newline), `\t` (tab), `\r` (carriage return), `\0` (null byte), and `\\` (a literal backslash). Write string parameters as follows:
+Pass Escaped-format text (not a raw Go string that already contains a newline or tab byte):
 
 | Value received by ClickHouse | Go raw string literal | Go interpreted string literal |
 |---|---|---|
-| Newline and tab | `` `line 1\\nline 2\\tend` `` | `"line 1\\\\nline 2\\\\tend"` |
-| Literal `\n` and `\t` text | `` `line 1\\\\nline 2\\\\tend` `` | `"line 1\\\\\\\\nline 2\\\\\\\\tend"` |
+| Newline and tab | `` `line 1\nline 2\tend` `` | `"line 1\\nline 2\\tend"` |
+| Literal `\n` and `\t` text | `` `line 1\\nline 2\\tend` `` | `"line 1\\\\nline 2\\\\tend"` |
 
-Do not use `` `line 1\nline 2` ``, `"line 1\\nline 2"`, or `"line 1\nline 2"` when the result should contain a newline. The first two forms lose their only backslash during quoted-value decoding; the last already contains an actual newline. In all three cases, the second parsing step sees an unescaped field delimiter and rejects the parameter as incompletely parsed.
+Do not use `"line 1\nline 2"` or `"column 1\tcolumn 2"` when constructing parameters. Those Go literals already contain an actual newline or tab; the server treats those bytes as field delimiters and rejects the value. Quotes and backslashes in ordinary strings (e.g. `it's`, `a\b`) are escaped by the helper.
 
-You can construct `[]proto.Parameter` directly, but then each `Value` must include the ClickHouse quotes and escaping that `ch.Parameters` normally adds. Prefer the helper unless you specifically need complete control over the wire representation.
+You can construct `[]proto.Parameter` directly, but then each `Value` must include the ClickHouse quotes and Field-dump escaping that `ch.Parameters` normally adds. Prefer the helper unless you specifically need complete control over the wire representation.
 
 [Full example](./examples/query_parameters)
 

--- a/examples/query_parameters/main.go
+++ b/examples/query_parameters/main.go
@@ -27,8 +27,8 @@ func main() {
 		literalBackslash   proto.ColStr
 	)
 
-	// ch.Parameters adds single quotes around each value. Backslash escapes
-	// therefore need to survive both quoted-value and parameter-value parsing.
+	// ch.Parameters quotes each value and escapes \ and ' for the Field dump.
+	// Pass Escaped-format text; \n / \t are interpreted after readQuoted.
 	err = conn.Do(ctx, ch.Query{
 		Body: `SELECT
 			{user_id:UInt64},
@@ -37,9 +37,9 @@ func main() {
 			{literal_backslash:String}`,
 		Parameters: ch.Parameters(map[string]any{
 			"user_id":             12345,
-			"escaped_raw":         `line 1\\nline 2\\tend`,
-			"escaped_interpreted": "line 1\\\\nline 2\\\\tend",
-			"literal_backslash":   `line 1\\\\nline 2`,
+			"escaped_raw":         `line 1\nline 2\tend`,
+			"escaped_interpreted": "line 1\\nline 2\\tend",
+			"literal_backslash":   `line 1\\nline 2`,
 		}),
 		Result: proto.Results{
 			{Data: &userID},

--- a/query_params.go
+++ b/query_params.go
@@ -3,17 +3,38 @@ package ch
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/ClickHouse/ch-go/proto"
 )
 
+// parameterQuoteEscaper escapes a value for a quoted Field dump. The server
+// restores custom settings / query parameters with readQuoted, so bare
+// backslashes and single quotes must be escaped before the value is wrapped
+// in quotes. Control characters are intentionally left alone: callers still
+// pass ClickHouse Escaped-format text (e.g. `\n` for a newline).
+var parameterQuoteEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`'`, `\'`,
+)
+
+// formatParameterValue formats v as a quoted Field dump for Query.Parameters.
+func formatParameterValue(v any) string {
+	return "'" + parameterQuoteEscaper.Replace(fmt.Sprint(v)) + "'"
+}
+
 // Parameters is a helper for building Query.Parameters.
 //
-// Each value is formatted with fmt and enclosed in single quotes. ClickHouse
-// decodes the quoted value before parsing it as the placeholder's declared
-// type. Consequently, backslash escape sequences need to survive two
-// ClickHouse parsing steps. For example, use `line 1\\nline 2` to receive a
-// newline, or `line 1\\\\nline 2` to receive the literal characters \ and n.
+// Each value is formatted with fmt and encoded as a quoted Field dump
+// (`'...'`), escaping `\` and `'` so the server's readQuoted step restores the
+// original text. ClickHouse then parses that text as the placeholder's
+// declared type using Escaped format, so backslash escapes such as `\n` and
+// `\t` are still interpreted there.
+//
+// Pass Escaped-format text (not a raw Go string with actual newlines). For
+// example, use `line 1\nline 2` to receive a newline, or `line 1\\nline 2`
+// to receive the literal characters \ and n. Actual tab/newline bytes are
+// rejected by the server.
 //
 // EXPERIMENTAL.
 func Parameters(m map[string]any) []proto.Parameter {
@@ -21,7 +42,7 @@ func Parameters(m map[string]any) []proto.Parameter {
 	for k, v := range m {
 		out = append(out, proto.Parameter{
 			Key:   k,
-			Value: fmt.Sprintf("'%v'", v),
+			Value: formatParameterValue(v),
 		})
 	}
 	// Sorting to make output deterministic.

--- a/query_params_format_test.go
+++ b/query_params_format_test.go
@@ -1,0 +1,45 @@
+package ch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatParameterValue(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{"plain string", "foo", `'foo'`},
+		{"integer", 100, `'100'`},
+		{"single quote", "it's", `'it\'s'`},
+		{"backslash", `a\b`, `'a\\b'`},
+		{"backslash before quote", `a\'b`, `'a\\\'b'`},
+		{"escaped newline text", `line 1\nline 2`, `'line 1\\nline 2'`},
+		{"literal backslash-n text", `line 1\\nline 2`, `'line 1\\\\nline 2'`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatParameterValue(tc.value))
+		})
+	}
+}
+
+func TestParametersEscapesQuotesAndBackslashes(t *testing.T) {
+	got := Parameters(map[string]any{
+		"q": "it's",
+		"b": `a\b`,
+		"n": 42,
+	})
+	require.Len(t, got, 3)
+	// Parameters sorts by key.
+	assert.Equal(t, "b", got[0].Key)
+	assert.Equal(t, `'a\\b'`, got[0].Value)
+	assert.Equal(t, "n", got[1].Key)
+	assert.Equal(t, `'42'`, got[1].Value)
+	assert.Equal(t, "q", got[2].Key)
+	assert.Equal(t, `'it\'s'`, got[2].Value)
+}

--- a/query_params_test.go
+++ b/query_params_test.go
@@ -17,6 +17,7 @@ func TestQueryParameters(t *testing.T) {
 	var (
 		num                proto.ColUInt8
 		str                proto.ColStr
+		quote              proto.ColStr
 		escapedRaw         proto.ColStr
 		escapedInterpreted proto.ColStr
 		literalBackslash   proto.ColStr
@@ -25,19 +26,22 @@ func TestQueryParameters(t *testing.T) {
 		Body: `SELECT
 			{num:UInt8},
 			{str:String},
+			{quote:String},
 			{escaped_raw:String},
 			{escaped_interpreted:String},
 			{literal_backslash:String}`,
 		Parameters: Parameters(map[string]any{
 			"num":                 100,
 			"str":                 "foo",
-			"escaped_raw":         `line 1\\nline 2\\tend`,
-			"escaped_interpreted": "line 1\\\\nline 2\\\\tend",
-			"literal_backslash":   `line 1\\\\nline 2`,
+			"quote":               "it's",
+			"escaped_raw":         `line 1\nline 2\tend`,
+			"escaped_interpreted": "line 1\\nline 2\\tend",
+			"literal_backslash":   `line 1\\nline 2`,
 		}),
 		Result: proto.Results{
 			{Data: &num},
 			{Data: &str},
+			{Data: &quote},
 			{Data: &escapedRaw},
 			{Data: &escapedInterpreted},
 			{Data: &literalBackslash},
@@ -45,6 +49,7 @@ func TestQueryParameters(t *testing.T) {
 	}))
 	require.Equal(t, uint8(100), num.Row(0))
 	require.Equal(t, "foo", str.Row(0))
+	require.Equal(t, "it's", quote.Row(0))
 	require.Equal(t, "line 1\nline 2\tend", escapedRaw.Row(0))
 	require.Equal(t, "line 1\nline 2\tend", escapedInterpreted.Row(0))
 	require.Equal(t, `line 1\nline 2`, literalBackslash.Row(0))
@@ -55,10 +60,13 @@ func TestQueryParameters(t *testing.T) {
 			value string
 			want  string
 		}{
-			{"raw literal with escapes", `line 1\\nline 2\\tend`, "line 1\nline 2\tend"},
-			{"interpreted literal with escaped backslashes", "line 1\\\\nline 2\\\\tend", "line 1\nline 2\tend"},
-			{"raw literal with literal backslashes", `line 1\\\\nline 2\\\\tend`, `line 1\nline 2\tend`},
-			{"interpreted literal with literal backslashes", "line 1\\\\\\\\nline 2\\\\\\\\tend", `line 1\nline 2\tend`},
+			{"raw literal with escapes", `line 1\nline 2\tend`, "line 1\nline 2\tend"},
+			{"interpreted literal with escaped backslashes", "line 1\\nline 2\\tend", "line 1\nline 2\tend"},
+			{"raw literal with literal backslashes", `line 1\\nline 2\\tend`, `line 1\nline 2\tend`},
+			{"interpreted literal with literal backslashes", "line 1\\\\nline 2\\\\tend", `line 1\nline 2\tend`},
+			{"single quote", "it's", "it's"},
+			// Escaped-format `\\` is a literal backslash; a lone `\b` would be backspace.
+			{"literal backslash", `a\\b`, `a\b`},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
@@ -74,9 +82,8 @@ func TestQueryParameters(t *testing.T) {
 		}
 
 		for name, value := range map[string]string{
-			"single escaped newline": `line 1\nline 2`,
-			"actual newline":         "line 1\nline 2",
-			"actual tab":             "column 1\tcolumn 2",
+			"actual newline": "line 1\nline 2",
+			"actual tab":     "column 1\tcolumn 2",
 		} {
 			t.Run("reject "+name, func(t *testing.T) {
 				conn := Conn(t)


### PR DESCRIPTION
## Summary
- `ch.Parameters` now encodes each value as a quoted Field dump, escaping `\` and `'` so the server's `readQuoted` step restores the text (`it's` → `'it\'s'`, `a\b` → `'a\\b'`).
- Callers pass **Escaped-format** text directly (e.g. `` `line 1\nline 2` `` for a newline). The previous extra backslash layer only existed because the helper did not escape.
- Docs, example, and tests updated. Raw tab/newline bytes are still rejected (no Named-style literal auto-escape).

Fixes #1198

## Breaking change (EXPERIMENTAL API)
Anyone who followed the old double-escape recipe must drop one backslash layer:

| Wanted value | Before | After |
|---|---|---|
| Newline | `` `line 1\\nline 2` `` | `` `line 1\nline 2` `` |
| Literal `\n` text | `` `line 1\\\\nline 2` `` | `` `line 1\\nline 2` `` |

## Test plan
- [x] `go test -run 'TestFormatParameterValue|TestParametersEscapesQuotesAndBackslashes' .`
- [ ] CI integration `TestQueryParameters` (needs ClickHouse)
- [ ] Confirm quote / backslash / Escaped `\n` cases round-trip on a live server

Made with [Cursor](https://cursor.com)